### PR TITLE
feat: implement board state module

### DIFF
--- a/Derelict/BoardState/.eslintrc.cjs
+++ b/Derelict/BoardState/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  env: { es2020: true, node: true },
+  parser: '@typescript-eslint/parser',
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parserOptions: { sourceType: 'module', ecmaVersion: 2020 },
+  ignorePatterns: ['dist'],
+  rules: {},
+};

--- a/Derelict/BoardState/.gitignore
+++ b/Derelict/BoardState/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/Derelict/BoardState/README.md
+++ b/Derelict/BoardState/README.md
@@ -1,0 +1,26 @@
+# Derelict Board State
+
+Utilities for representing and mutating grid based board states for the game *Derelict*.
+
+## Development
+
+```
+npm install
+npm test
+```
+
+### Scripts
+
+- `npm run build` – compile TypeScript
+- `npm test` – run node:test
+- `npm run lint` – eslint
+- `npm run format` – prettier
+
+## Example
+
+```ts
+import { newBoard, addSegment } from './src/api/public.js';
+// assuming `segText` and `tokText` hold library text
+const state = newBoard(40, segText, tokText);
+addSegment(state, { instanceId: 'S1', type: 'room', origin: { x: 0, y: 0 }, rot: 0 });
+```

--- a/Derelict/BoardState/fixtures/lib_segments.txt
+++ b/Derelict/BoardState/fixtures/lib_segments.txt
@@ -1,0 +1,19 @@
+legend: 0=wall, 1=corridor
+segment L_room_5x5 5x5
+0 0 1 0 0
+0 1 1 1 0
+1 1 1 1 0
+0 1 1 1 0
+0 0 0 0 0
+endsegment
+
+segment corridor_5 3x5
+0 0 0 0 0
+1 1 1 1 1
+0 0 0 0 0
+endsegment
+
+segment endcap 2x2
+0 0
+0 1
+endsegment

--- a/Derelict/BoardState/fixtures/lib_tokens.txt
+++ b/Derelict/BoardState/fixtures/lib_tokens.txt
@@ -1,0 +1,5 @@
+version: 1
+type=door
+type=marine
+type=blip
+type=objective

--- a/Derelict/BoardState/fixtures/mission.txt
+++ b/Derelict/BoardState/fixtures/mission.txt
@@ -1,0 +1,13 @@
+mission: Cleanse the Corridor
+board: 40x40
+segments: lib_segments.txt
+tokenlib: lib_tokens.txt
+
+instances:
+  S1: L_room_5x5 pos=(10,10) rot=0
+  S2: corridor_5  pos=(15,10) rot=90
+  S3: endcap      pos=(15,15) rot=180
+
+tokens:
+  D1: type=door   orient=90  cells=(13,12)
+  M1: type=marine orient=180 cells=(11,12) attrs={"owner":"red"}

--- a/Derelict/BoardState/package.json
+++ b/Derelict/BoardState/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "derelict-boardstate",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test tests",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "format": "prettier -w ."
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "typescript": "^5.2.2",
+    "prettier": "^3.0.0"
+  }
+}

--- a/Derelict/BoardState/src/api/public.ts
+++ b/Derelict/BoardState/src/api/public.ts
@@ -1,0 +1,76 @@
+import { BoardState, Coord, SegmentInstance, TokenInstance, Id } from '../core/types.js';
+import { parseSegmentLibrary } from '../io/segmentLib.parse.js';
+import { parseTokenLibrary } from '../io/tokenLib.parse.js';
+import { parseMission } from '../io/mission.parse.js';
+import { serializeMission } from '../io/mission.serialize.js';
+import { createState, placeSegment, removeSegmentAtCoordInternal, placeToken, removeTokenInternal, cellTypeAt, cellsInSameSegment, tokensAt, findByIdInternal } from '../core/boardState.js';
+
+export function newBoard(size: number, segmentLibrary: string, tokenLibrary: string): BoardState {
+  const segDefs = parseSegmentLibrary(segmentLibrary);
+  const tokDefs = parseTokenLibrary(tokenLibrary);
+  return createState(size, segDefs, tokDefs);
+}
+
+export function loadBoard(size: number, segmentLibrary: string, tokenLibrary: string, missionFile: string): BoardState {
+  const segDefs = parseSegmentLibrary(segmentLibrary);
+  const tokDefs = parseTokenLibrary(tokenLibrary);
+  const mission = parseMission(missionFile);
+  const state = createState(mission.size || size, segDefs, tokDefs);
+  for (const s of mission.segments) {
+    placeSegment(state, s);
+  }
+  for (const t of mission.tokens) {
+    placeToken(state, t);
+  }
+  return state;
+}
+
+export function saveBoard(state: BoardState, missionName: string): string {
+  return serializeMission(state, missionName);
+}
+
+// Mutations
+export function addSegment(state: BoardState, seg: SegmentInstance): void {
+  placeSegment(state as any, seg);
+}
+
+export function removeSegmentAtCoord(state: BoardState, coord: Coord): void {
+  removeSegmentAtCoordInternal(state as any, coord);
+}
+
+export function addToken(state: BoardState, tok: TokenInstance): void {
+  placeToken(state as any, tok);
+}
+
+export function removeToken(state: BoardState, tokenId: Id): void {
+  removeTokenInternal(state as any, tokenId);
+}
+
+// Queries
+export function getCellType(state: BoardState, coord: Coord): number {
+  return cellTypeAt(state as any, coord);
+}
+
+export function getCellsInSameSegment(state: BoardState, coord: Coord): Coord[] {
+  return cellsInSameSegment(state as any, coord);
+}
+
+export function getTokensAt(state: BoardState, coord: Coord): TokenInstance[] {
+  return tokensAt(state as any, coord);
+}
+
+export function getBoardDimensions(state: BoardState): { width: number; height: number } {
+  return { width: state.size, height: state.size };
+}
+
+export function getSegmentInstances(state: BoardState): SegmentInstance[] {
+  return state.segments;
+}
+
+export function getTokens(state: BoardState): TokenInstance[] {
+  return state.tokens;
+}
+
+export function findById(state: BoardState, id: Id): SegmentInstance | TokenInstance | undefined {
+  return findByIdInternal(state as any, id);
+}

--- a/Derelict/BoardState/src/core/boardState.ts
+++ b/Derelict/BoardState/src/core/boardState.ts
@@ -1,0 +1,126 @@
+import { BoardState, SegmentInstance, TokenInstance, SegmentDef, TokenDef, Coord, CellType, Id } from './types.js';
+import { BoardError, ERR_BAD_COORD, ERR_OVERLAP, ERR_UNKNOWN_SEGMENT_DEF, ERR_UNKNOWN_TOKEN_TYPE } from './errors.js';
+import { createIndices, segmentCells, key, Indices } from './indices.js';
+
+const SEGMENT_DEFS = Symbol('segmentDefs');
+const TOKEN_DEFS = Symbol('tokenDefs');
+const INDICES = Symbol('indices');
+
+export interface InternalState extends BoardState {
+  [SEGMENT_DEFS]: Map<string, SegmentDef>;
+  [TOKEN_DEFS]: Map<string, TokenDef>;
+  [INDICES]: Indices;
+}
+
+export function createState(size: number, segDefs: Map<string, SegmentDef>, tokDefs: Map<string, TokenDef>): InternalState {
+  const state: InternalState = {
+    size,
+    segments: [],
+    tokens: [],
+    [SEGMENT_DEFS]: segDefs,
+    [TOKEN_DEFS]: tokDefs,
+    [INDICES]: createIndices(),
+  };
+  return state;
+}
+
+function assertInBounds(state: InternalState, c: Coord) {
+  if (c.x < 0 || c.y < 0 || c.x >= state.size || c.y >= state.size) {
+    throw new BoardError(ERR_BAD_COORD, `Coord out of bounds (${c.x},${c.y})`, c);
+  }
+}
+
+export function placeSegment(state: InternalState, inst: SegmentInstance): void {
+  const def = state[SEGMENT_DEFS].get(inst.type);
+  if (!def) throw new BoardError(ERR_UNKNOWN_SEGMENT_DEF, `Unknown segment type ${inst.type}`);
+  const cells = segmentCells(inst, def);
+  const idx = state[INDICES];
+  const conflicts: Coord[] = [];
+  for (const { coord } of cells) {
+    assertInBounds(state, coord);
+    if (idx.segCells.has(key(coord))) conflicts.push(coord);
+  }
+  if (conflicts.length) {
+    throw new BoardError(ERR_OVERLAP, 'segment overlap', conflicts[0]);
+  }
+  for (const { coord, cellType } of cells) {
+    idx.segCells.set(key(coord), { instanceId: inst.instanceId, cellType });
+  }
+  state.segments.push(inst);
+  idx.segmentsById.set(inst.instanceId, inst);
+}
+
+export function removeSegmentAtCoordInternal(state: InternalState, coord: Coord): void {
+  const idx = state[INDICES];
+  const info = idx.segCells.get(key(coord));
+  if (!info) return;
+  const inst = idx.segmentsById.get(info.instanceId);
+  if (!inst) return;
+  const def = state[SEGMENT_DEFS].get(inst.type)!;
+  const cells = segmentCells(inst, def);
+  for (const { coord: c } of cells) {
+    idx.segCells.delete(key(c));
+  }
+  idx.segmentsById.delete(inst.instanceId);
+  state.segments = state.segments.filter((s) => s.instanceId !== inst.instanceId);
+}
+
+export function placeToken(state: InternalState, tok: TokenInstance): void {
+  if (!state[TOKEN_DEFS].has(tok.type)) {
+    throw new BoardError(ERR_UNKNOWN_TOKEN_TYPE, `Unknown token type ${tok.type}`);
+  }
+  const idx = state[INDICES];
+  for (const c of tok.cells) {
+    assertInBounds(state, c);
+  }
+  state.tokens.push(tok);
+  idx.tokensById.set(tok.instanceId, tok);
+  for (const c of tok.cells) {
+    const k = key(c);
+    const list = idx.tokenCells.get(k) || [];
+    list.push(tok.instanceId);
+    idx.tokenCells.set(k, list);
+  }
+}
+
+export function removeTokenInternal(state: InternalState, tokenId: Id): void {
+  const idx = state[INDICES];
+  const tok = idx.tokensById.get(tokenId);
+  if (!tok) return;
+  for (const c of tok.cells) {
+    const k = key(c);
+    const list = idx.tokenCells.get(k);
+    if (list) {
+      idx.tokenCells.set(k, list.filter((id) => id !== tokenId));
+    }
+  }
+  idx.tokensById.delete(tokenId);
+  state.tokens = state.tokens.filter((t) => t.instanceId !== tokenId);
+}
+
+// Queries
+export function cellTypeAt(state: InternalState, coord: Coord): CellType | -1 {
+  const info = state[INDICES].segCells.get(key(coord));
+  return info ? info.cellType : -1;
+}
+
+export function tokensAt(state: InternalState, coord: Coord): TokenInstance[] {
+  const ids = state[INDICES].tokenCells.get(key(coord)) || [];
+  return ids.map((id) => state[INDICES].tokensById.get(id)!).filter(Boolean);
+}
+
+export function cellsInSameSegment(state: InternalState, coord: Coord): Coord[] {
+  const info = state[INDICES].segCells.get(key(coord));
+  if (!info) return [];
+  const inst = state[INDICES].segmentsById.get(info.instanceId)!;
+  const def = state[SEGMENT_DEFS].get(inst.type)!;
+  return segmentCells(inst, def).map((c) => c.coord);
+}
+
+export function findByIdInternal(state: InternalState, id: Id): SegmentInstance | TokenInstance | undefined {
+  return state[INDICES].segmentsById.get(id) || state[INDICES].tokensById.get(id);
+}
+
+export function getIndices(state: InternalState): Indices {
+  return state[INDICES];
+}

--- a/Derelict/BoardState/src/core/errors.ts
+++ b/Derelict/BoardState/src/core/errors.ts
@@ -1,0 +1,17 @@
+export class BoardError extends Error {
+  code: string;
+  details?: unknown;
+  constructor(code: string, message: string, details?: unknown) {
+    super(message);
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export const ERR_BAD_GLYPH = 'ERR_BAD_GLYPH';
+export const ERR_BAD_COORD = 'ERR_BAD_COORD';
+export const ERR_OVERLAP = 'ERR_OVERLAP';
+export const ERR_PARSE = 'ERR_PARSE';
+export const ERR_DUP_ID = 'ERR_DUP_ID';
+export const ERR_UNKNOWN_SEGMENT_DEF = 'ERR_UNKNOWN_SEGMENT_DEF';
+export const ERR_UNKNOWN_TOKEN_TYPE = 'ERR_UNKNOWN_TOKEN_TYPE';

--- a/Derelict/BoardState/src/core/indices.ts
+++ b/Derelict/BoardState/src/core/indices.ts
@@ -1,0 +1,47 @@
+import { Coord, Rotation, SegmentDef, SegmentInstance, CellType, Id, TokenInstance } from './types.js';
+
+export interface SegmentCell { instanceId: Id; cellType: CellType }
+
+export interface Indices {
+  segCells: Map<string, SegmentCell>;
+  tokenCells: Map<string, Id[]>;
+  tokensById: Map<Id, TokenInstance>;
+  segmentsById: Map<Id, SegmentInstance>;
+}
+
+export function createIndices(): Indices {
+  return { segCells: new Map(), tokenCells: new Map(), tokensById: new Map(), segmentsById: new Map() };
+}
+
+export function key(c: Coord): string {
+  return `${c.x},${c.y}`;
+}
+
+export function rotate(local: Coord, rot: Rotation, def: SegmentDef): Coord {
+  const { width, height } = def;
+  const x = local.x;
+  const y = local.y;
+  switch (rot) {
+    case 0:
+      return { x, y };
+    case 90:
+      return { x: height - 1 - y, y: x };
+    case 180:
+      return { x: width - 1 - x, y: height - 1 - y };
+    case 270:
+      return { x: y, y: width - 1 - x };
+  }
+}
+
+export function segmentCells(inst: SegmentInstance, def: SegmentDef): { coord: Coord; cellType: CellType }[] {
+  const cells: { coord: Coord; cellType: CellType }[] = [];
+  for (let y = 0; y < def.height; y++) {
+    for (let x = 0; x < def.width; x++) {
+      const rotCoord = rotate({ x, y }, inst.rot, def);
+      const global = { x: inst.origin.x + rotCoord.x, y: inst.origin.y + rotCoord.y };
+      const cellType = def.grid[y][x];
+      cells.push({ coord: global, cellType });
+    }
+  }
+  return cells;
+}

--- a/Derelict/BoardState/src/core/types.ts
+++ b/Derelict/BoardState/src/core/types.ts
@@ -1,0 +1,44 @@
+export type Rotation = 0 | 90 | 180 | 270;
+export type CellType = number; // 0=wall, 1=corridor
+
+export interface Coord { x: number; y: number; }
+export type Id = string;
+
+export interface SegmentDef {
+  segmentId: Id;
+  width: number;
+  height: number;
+  grid: CellType[][]; // [row][col], rectangular
+}
+
+export interface SegmentInstance {
+  instanceId: Id;
+  type: string;  // must exist in Segment Library
+  origin: Coord;  // upper-left in board coords before rotation application
+  rot: Rotation;  // clockwise
+}
+
+export interface TokenInstance {
+  instanceId: Id;
+  type: string;        // must exist in Token Library
+  rot: Rotation;
+  cells: Coord[];
+  attrs?: Record<string, unknown>;
+}
+
+export interface BoardState {
+  size: number; // board is size x size (square)
+  segments: SegmentInstance[];
+  tokens: TokenInstance[];
+}
+
+export interface TokenDef {
+  type: string;
+  notes?: string;
+}
+
+export interface Diagnostics {
+  code: string;
+  message: string;
+  details?: unknown;
+}

--- a/Derelict/BoardState/src/io/mission.parse.ts
+++ b/Derelict/BoardState/src/io/mission.parse.ts
@@ -1,0 +1,67 @@
+import { SegmentInstance, TokenInstance, Rotation, Coord } from '../core/types.js';
+import { parseCoord, parseCoordList, parseRotation, trimLines } from '../util/text.js';
+
+export interface MissionData {
+  name: string;
+  size: number;
+  segments: SegmentInstance[];
+  tokens: TokenInstance[];
+}
+
+export function parseMission(text: string): MissionData {
+  const lines = trimLines(text);
+  let name = '';
+  let size = 0;
+  const segments: SegmentInstance[] = [];
+  const tokens: TokenInstance[] = [];
+  let mode: 'instances' | 'tokens' | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith('mission:')) {
+      name = line.slice(8).trim();
+      continue;
+    }
+    if (line.startsWith('board:')) {
+      const m = line.match(/(\d+)x(\d+)/);
+      if (m) size = parseInt(m[1], 10);
+      continue;
+    }
+    if (line.startsWith('segments:') || line.startsWith('tokenlib:')) {
+      continue; // provenance ignored
+    }
+    if (line.startsWith('instances:')) {
+      mode = 'instances';
+      continue;
+    }
+    if (line.startsWith('tokens:')) {
+      mode = 'tokens';
+      continue;
+    }
+    if (mode === 'instances') {
+      const m = line.match(/(\S+):\s+(\S+)\s+pos=(\([^\)]+\))\s+rot=(\d+)/);
+      if (!m) continue;
+      const inst: SegmentInstance = {
+        instanceId: m[1],
+        type: m[2],
+        origin: parseCoord(m[3]),
+        rot: parseRotation(m[4]) as Rotation,
+      };
+      segments.push(inst);
+      continue;
+    }
+    if (mode === 'tokens') {
+      const m = line.match(/(\S+):\s+type=(\S+)\s+orient=(\d+)\s+cells=([^\s]+)(?:\s+attrs=(.+))?/);
+      if (!m) continue;
+      const tok: TokenInstance = {
+        instanceId: m[1],
+        type: m[2],
+        rot: parseRotation(m[3]) as Rotation,
+        cells: parseCoordList(m[4]),
+      };
+      if (m[5]) tok.attrs = JSON.parse(m[5]);
+      tokens.push(tok);
+      continue;
+    }
+  }
+  return { name, size, segments, tokens };
+}

--- a/Derelict/BoardState/src/io/mission.serialize.ts
+++ b/Derelict/BoardState/src/io/mission.serialize.ts
@@ -1,0 +1,22 @@
+import { BoardState } from '../core/types.js';
+
+export function serializeMission(state: BoardState, missionName = 'Untitled'): string {
+  const lines: string[] = [];
+  lines.push(`mission: ${missionName}`);
+  lines.push(`board: ${state.size}x${state.size}`);
+  lines.push('');
+  lines.push('instances:');
+  const segs = [...state.segments].sort((a, b) => a.instanceId.localeCompare(b.instanceId));
+  for (const s of segs) {
+    lines.push(`  ${s.instanceId}: ${s.type} pos=(${s.origin.x},${s.origin.y}) rot=${s.rot}`);
+  }
+  lines.push('');
+  lines.push('tokens:');
+  const toks = [...state.tokens].sort((a, b) => a.instanceId.localeCompare(b.instanceId));
+  for (const t of toks) {
+    const cells = t.cells.map((c) => `(${c.x},${c.y})`).join(',');
+    const attr = t.attrs ? ` attrs=${JSON.stringify(t.attrs)}` : '';
+    lines.push(`  ${t.instanceId}: type=${t.type} orient=${t.rot} cells=${cells}${attr}`);
+  }
+  return lines.join('\n');
+}

--- a/Derelict/BoardState/src/io/save.serialize.ts
+++ b/Derelict/BoardState/src/io/save.serialize.ts
@@ -1,0 +1,18 @@
+import { BoardState } from '../core/types.js';
+import { createState, placeSegment, placeToken } from '../core/boardState.js';
+
+export function serializeSave(state: BoardState): string {
+  return JSON.stringify(state, null, 2);
+}
+
+export function deserializeSave(text: string, segDefs: Map<string, any>, tokDefs: Map<string, any>): BoardState {
+  const obj = JSON.parse(text) as BoardState;
+  const state = createState(obj.size, segDefs, tokDefs);
+  for (const s of obj.segments) {
+    placeSegment(state, s);
+  }
+  for (const t of obj.tokens) {
+    placeToken(state, t);
+  }
+  return state;
+}

--- a/Derelict/BoardState/src/io/segmentLib.parse.ts
+++ b/Derelict/BoardState/src/io/segmentLib.parse.ts
@@ -1,0 +1,47 @@
+import { SegmentDef, CellType, Id } from '../core/types.js';
+import { BoardError, ERR_BAD_GLYPH, ERR_PARSE, ERR_DUP_ID } from '../core/errors.js';
+import { trimLines } from '../util/text.js';
+
+export function parseSegmentLibrary(text: string): Map<Id, SegmentDef> {
+  const lines = trimLines(text);
+  const legend: Set<number> = new Set([0, 1]);
+  const segments = new Map<Id, SegmentDef>();
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.startsWith('legend:')) {
+      const part = line.slice(7);
+      for (const entry of part.split(',')) {
+        const m = entry.trim().match(/(\d+)=/);
+        if (m) legend.add(parseInt(m[1], 10));
+      }
+      i++;
+      continue;
+    }
+    if (line.startsWith('segment')) {
+      const m = line.match(/^segment\s+(\S+)\s+(\d+)x(\d+)$/);
+      if (!m) throw new BoardError(ERR_PARSE, 'bad segment header');
+      const id = m[1];
+      const h = parseInt(m[2], 10);
+      const w = parseInt(m[3], 10);
+      if (segments.has(id)) throw new BoardError(ERR_DUP_ID, `duplicate segment id ${id}`);
+      const grid: CellType[][] = [];
+      i++;
+      for (let r = 0; r < h; r++, i++) {
+        if (i >= lines.length) throw new BoardError(ERR_PARSE, 'unexpected EOF');
+        const row = lines[i].split(/\s+/).map((n) => parseInt(n, 10));
+        if (row.length !== w) throw new BoardError(ERR_PARSE, 'ragged row');
+        for (const cell of row) {
+          if (!legend.has(cell)) throw new BoardError(ERR_BAD_GLYPH, `unknown glyph ${cell}`);
+        }
+        grid.push(row);
+      }
+      if (lines[i] !== 'endsegment') throw new BoardError(ERR_PARSE, 'missing endsegment');
+      segments.set(id, { segmentId: id, width: w, height: h, grid });
+      i++;
+      continue;
+    }
+    throw new BoardError(ERR_PARSE, `unrecognized line: ${line}`);
+  }
+  return segments;
+}

--- a/Derelict/BoardState/src/io/tokenLib.parse.ts
+++ b/Derelict/BoardState/src/io/tokenLib.parse.ts
@@ -1,0 +1,17 @@
+import { TokenDef } from '../core/types.js';
+import { BoardError, ERR_PARSE } from '../core/errors.js';
+import { trimLines } from '../util/text.js';
+
+export function parseTokenLibrary(text: string): Map<string, TokenDef> {
+  const lines = trimLines(text);
+  const map = new Map<string, TokenDef>();
+  for (const line of lines) {
+    if (line.startsWith('version:')) continue;
+    const m = line.match(/^type=(\S+)(?:\s+notes="([^"]*)")?$/);
+    if (!m) throw new BoardError(ERR_PARSE, `bad token line: ${line}`);
+    const id = m[1];
+    const notes = m[2];
+    map.set(id, { type: id, notes });
+  }
+  return map;
+}

--- a/Derelict/BoardState/src/util/text.ts
+++ b/Derelict/BoardState/src/util/text.ts
@@ -1,0 +1,30 @@
+import { Coord, Rotation } from '../core/types.js';
+
+export function trimLines(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith('#'));
+}
+
+export function parseCoord(str: string): Coord {
+  const m = str.match(/\(([-\d]+),([-\d]+)\)/);
+  if (!m) throw new Error(`Bad coord: ${str}`);
+  return { x: parseInt(m[1], 10), y: parseInt(m[2], 10) };
+}
+
+export function parseCoordList(str: string): Coord[] {
+  const coords: Coord[] = [];
+  const parts = str.split(/\),/);
+  for (const p of parts) {
+    const t = p.endsWith(')') ? p : p + ')';
+    coords.push(parseCoord(t));
+  }
+  return coords;
+}
+
+export function parseRotation(str: string): Rotation {
+  const r = parseInt(str, 10) as Rotation;
+  if (![0, 90, 180, 270].includes(r)) throw new Error(`Bad rotation: ${str}`);
+  return r;
+}

--- a/Derelict/BoardState/tests/mission.test.js
+++ b/Derelict/BoardState/tests/mission.test.js
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { loadBoard, saveBoard } from '../dist/api/public.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('mission import/export', () => {
+  const segLib = fixture('lib_segments.txt');
+  const tokLib = fixture('lib_tokens.txt');
+  const missionText = fixture('mission.txt');
+
+  it('import mission builds expected BoardState', () => {
+    const board = loadBoard(40, segLib, tokLib, missionText);
+    assert.strictEqual(board.segments.length, 3);
+    assert.strictEqual(board.tokens.length, 2);
+  });
+
+  it('export -> import preserves IDs', () => {
+    const board = loadBoard(40, segLib, tokLib, missionText);
+    const text = saveBoard(board, 'Test');
+    const board2 = loadBoard(40, segLib, tokLib, text);
+    assert.deepStrictEqual(board2, board);
+  });
+
+  it('deterministic export ordering', () => {
+    const board = loadBoard(40, segLib, tokLib, missionText);
+    const text1 = saveBoard(board, 'Test');
+    const text2 = saveBoard(board, 'Test');
+    assert.strictEqual(text1, text2);
+  });
+});
+

--- a/Derelict/BoardState/tests/performance.test.js
+++ b/Derelict/BoardState/tests/performance.test.js
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { performance } from 'perf_hooks';
+import { newBoard, addSegment, addToken, getCellType, getTokensAt } from '../dist/api/public.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('performance', () => {
+  const segLib = fixture('lib_segments.txt');
+  const tokLib = fixture('lib_tokens.txt');
+
+  it('50 segment placements + 100 token ops under 1s', () => {
+    const board = newBoard(100, segLib, tokLib);
+    const start = performance.now();
+    for (let i = 0; i < 50; i++) {
+      addSegment(board, { instanceId: `S${i}`, type: 'endcap', origin: { x: i * 2, y: i * 2 }, rot: 0 });
+    }
+    for (let i = 0; i < 100; i++) {
+      addToken(board, { instanceId: `T${i}`, type: 'door', rot: 0, cells: [{ x: i, y: i }] });
+    }
+    const elapsed = performance.now() - start;
+    assert.ok(elapsed < 1000);
+  });
+
+  it('10k getCellType + getTokensAt lookups remain fast', () => {
+    const board = newBoard(40, segLib, tokLib);
+    addSegment(board, { instanceId: 'S', type: 'endcap', origin: { x: 0, y: 0 }, rot: 0 });
+    addToken(board, { instanceId: 'T', type: 'door', rot: 0, cells: [{ x: 0, y: 0 }] });
+    const start = performance.now();
+    for (let i = 0; i < 10000; i++) {
+      const x = i % 40;
+      const y = Math.floor(i / 40);
+      getCellType(board, { x, y });
+      getTokensAt(board, { x, y });
+    }
+    const elapsed = performance.now() - start;
+    assert.ok(elapsed < 1000);
+  });
+});
+

--- a/Derelict/BoardState/tests/placement.test.js
+++ b/Derelict/BoardState/tests/placement.test.js
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { newBoard, addSegment, getCellType } from '../dist/api/public.js';
+import { ERR_OVERLAP } from '../dist/core/errors.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('segment placement', () => {
+  const segLib = fixture('lib_segments.txt');
+  const tokLib = fixture('lib_tokens.txt');
+
+  it('place non-overlapping segments', () => {
+    const board = newBoard(40, segLib, tokLib);
+    addSegment(board, { instanceId: 'S1', type: 'L_room_5x5', origin: { x: 0, y: 0 }, rot: 0 });
+    addSegment(board, { instanceId: 'S2', type: 'endcap', origin: { x: 10, y: 10 }, rot: 0 });
+    assert.strictEqual(board.segments.length, 2);
+  });
+
+  it('place overlapping segments -> ERR_OVERLAP with conflict coord', () => {
+    const board = newBoard(40, segLib, tokLib);
+    addSegment(board, { instanceId: 'S1', type: 'L_room_5x5', origin: { x: 0, y: 0 }, rot: 0 });
+    assert.throws(
+      () => addSegment(board, { instanceId: 'S2', type: 'endcap', origin: { x: 0, y: 0 }, rot: 0 }),
+      (e) => e.code === ERR_OVERLAP
+    );
+  });
+
+  it('rotations 0/90/180/270 map correctly', () => {
+    const origin = { x: 5, y: 5 };
+    const positions = [
+      { rot: 0, coord: { x: 6, y: 6 } },
+      { rot: 90, coord: { x: 5, y: 6 } },
+      { rot: 180, coord: { x: 5, y: 5 } },
+      { rot: 270, coord: { x: 6, y: 5 } },
+    ];
+    for (const [i, p] of positions.entries()) {
+      const board2 = newBoard(20, segLib, tokLib);
+      addSegment(board2, { instanceId: `S${i}`, type: 'endcap', origin, rot: p.rot });
+      assert.strictEqual(getCellType(board2, p.coord), 1);
+    }
+  });
+});
+

--- a/Derelict/BoardState/tests/queries.test.js
+++ b/Derelict/BoardState/tests/queries.test.js
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { loadBoard, getCellType, getCellsInSameSegment, findById } from '../dist/api/public.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('queries', () => {
+  const segLib = fixture('lib_segments.txt');
+  const tokLib = fixture('lib_tokens.txt');
+  const missionText = fixture('mission.txt');
+  const board = loadBoard(40, segLib, tokLib, missionText);
+
+  it('getCellType returns -1 for uncovered and correct for covered', () => {
+    assert.strictEqual(getCellType(board, { x: 0, y: 0 }), -1);
+    assert.strictEqual(getCellType(board, { x: 12, y: 12 }), 1);
+  });
+
+  it('getCellsInSameSegment floods within owning rectangle', () => {
+    const cells = getCellsInSameSegment(board, { x: 12, y: 12 });
+    assert.strictEqual(cells.length, 25);
+    assert.ok(cells.some((c) => c.x === 10 && c.y === 10));
+    assert.ok(!cells.some((c) => c.x === 0 && c.y === 0));
+  });
+
+  it('findById returns correct object', () => {
+    assert.strictEqual(findById(board, 'S1').type, 'L_room_5x5');
+    assert.strictEqual(findById(board, 'D1').type, 'door');
+  });
+});
+

--- a/Derelict/BoardState/tests/segmentLib.test.js
+++ b/Derelict/BoardState/tests/segmentLib.test.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { parseSegmentLibrary } from '../dist/io/segmentLib.parse.js';
+import { ERR_BAD_GLYPH, ERR_PARSE } from '../dist/core/errors.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('segment library', () => {
+  it('parses default legend and multiple segments', () => {
+    const lib = parseSegmentLibrary(fixture('lib_segments.txt'));
+    assert.strictEqual(lib.size, 3);
+    assert.strictEqual(lib.get('L_room_5x5').width, 5);
+  });
+
+  it('ragged rows -> ERR_PARSE', () => {
+    const text = 'segment bad 2x2\n0 1 2\n0 1\nendsegment';
+    assert.throws(() => parseSegmentLibrary(text), (e) => e.code === ERR_PARSE);
+  });
+
+  it('unknown cell type integer -> ERR_BAD_GLYPH', () => {
+    const text = 'segment bad 1x1\n9\nendsegment';
+    assert.throws(() => parseSegmentLibrary(text), (e) => e.code === ERR_BAD_GLYPH);
+  });
+});
+

--- a/Derelict/BoardState/tests/serialization.test.js
+++ b/Derelict/BoardState/tests/serialization.test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { newBoard, addSegment, addToken } from '../dist/api/public.js';
+import { serializeSave, deserializeSave } from '../dist/io/save.serialize.js';
+import { parseSegmentLibrary } from '../dist/io/segmentLib.parse.js';
+import { parseTokenLibrary } from '../dist/io/tokenLib.parse.js';
+import { ERR_BAD_COORD } from '../dist/core/errors.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('serialization', () => {
+  const segLibText = fixture('lib_segments.txt');
+  const tokLibText = fixture('lib_tokens.txt');
+  const segDefs = parseSegmentLibrary(segLibText);
+  const tokDefs = parseTokenLibrary(tokLibText);
+
+  it('save JSON round-trip preserves IDs/attrs', () => {
+    const board = newBoard(40, segLibText, tokLibText);
+    addSegment(board, { instanceId: 'S1', type: 'endcap', origin: { x: 1, y: 1 }, rot: 0 });
+    addToken(board, { instanceId: 'T1', type: 'door', rot: 0, cells: [{ x: 2, y: 2 }], attrs: { a: 1 } });
+    const json = serializeSave(board);
+    const board2 = deserializeSave(json, segDefs, tokDefs);
+    assert.deepStrictEqual(board2, board);
+  });
+
+  it('board resize errors when shrinking below existing coords', () => {
+    const board = newBoard(40, segLibText, tokLibText);
+    addSegment(board, { instanceId: 'S1', type: 'endcap', origin: { x: 10, y: 10 }, rot: 0 });
+    const json = serializeSave(board);
+    const small = JSON.stringify({ ...JSON.parse(json), size: 5 });
+    assert.throws(() => deserializeSave(small, segDefs, tokDefs), (e) => e.code === ERR_BAD_COORD);
+  });
+});
+

--- a/Derelict/BoardState/tests/tokenLib.test.js
+++ b/Derelict/BoardState/tests/tokenLib.test.js
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { parseTokenLibrary } from '../dist/io/tokenLib.parse.js';
+import { newBoard, addToken } from '../dist/api/public.js';
+import { ERR_UNKNOWN_TOKEN_TYPE } from '../dist/core/errors.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('token library', () => {
+  it('loads types; duplicate last-write-wins', () => {
+    const text = 'version: 1\ntype=a notes="x"\ntype=a notes="y"';
+    const lib = parseTokenLibrary(text);
+    assert.strictEqual(lib.get('a').notes, 'y');
+  });
+
+  it('unknown token type in mission -> ERR_UNKNOWN_TOKEN_TYPE', () => {
+    const segLib = fixture('lib_segments.txt');
+    const tokLib = 'version:1\ntype=marine';
+    const board = newBoard(10, segLib, tokLib);
+    const token = { instanceId: 'T1', type: 'door', rot: 0, cells: [{ x: 0, y: 0 }] };
+    assert.throws(() => addToken(board, token), (e) => e.code === ERR_UNKNOWN_TOKEN_TYPE);
+  });
+});
+

--- a/Derelict/BoardState/tests/tokens.test.js
+++ b/Derelict/BoardState/tests/tokens.test.js
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { newBoard, addToken, getTokensAt } from '../dist/api/public.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('tokens', () => {
+  const segLib = fixture('lib_segments.txt');
+  const tokLib = fixture('lib_tokens.txt');
+
+  it('single-cell token appears in getTokensAt', () => {
+    const board = newBoard(10, segLib, tokLib);
+    const t = { instanceId: 'T1', type: 'door', rot: 0, cells: [{ x: 1, y: 1 }] };
+    addToken(board, t);
+    assert.strictEqual(getTokensAt(board, { x: 1, y: 1 }).length, 1);
+  });
+
+  it('multi-cell token appears in all covered cells', () => {
+    const board = newBoard(10, segLib, tokLib);
+    const t = { instanceId: 'T1', type: 'door', rot: 0, cells: [{ x: 2, y: 2 }, { x: 2, y: 3 }] };
+    addToken(board, t);
+    assert.strictEqual(getTokensAt(board, { x: 2, y: 2 }).length, 1);
+    assert.strictEqual(getTokensAt(board, { x: 2, y: 3 }).length, 1);
+  });
+
+  it('overlapping tokens coexist', () => {
+    const board = newBoard(10, segLib, tokLib);
+    addToken(board, { instanceId: 'T1', type: 'door', rot: 0, cells: [{ x: 1, y: 1 }] });
+    addToken(board, { instanceId: 'T2', type: 'door', rot: 0, cells: [{ x: 1, y: 1 }] });
+    assert.strictEqual(getTokensAt(board, { x: 1, y: 1 }).length, 2);
+  });
+
+  it('rotating a token updates rot only; cells unchanged', () => {
+    const board = newBoard(10, segLib, tokLib);
+    const t = { instanceId: 'T1', type: 'door', rot: 0, cells: [{ x: 1, y: 1 }] };
+    addToken(board, t);
+    const token = getTokensAt(board, { x: 1, y: 1 })[0];
+    token.rot = 90;
+    assert.strictEqual(token.rot, 90);
+    assert.deepStrictEqual(token.cells[0], { x: 1, y: 1 });
+  });
+});
+

--- a/Derelict/BoardState/tsconfig.json
+++ b/Derelict/BoardState/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["tests", "dist"]
+}


### PR DESCRIPTION
## Summary
- implement board state core logic, indices and error handling
- add text parsers for segments, tokens, mission files and JSON save
- provide query and mutation APIs with fixtures and tests
- migrate tests to Node's built-in test runner

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689902fd618c8333afd7993ba5b03615