### PR TITLE
feat: add canvas renderer

### DIFF
--- a/Derelict/Renderer/README.md
+++ b/Derelict/Renderer/README.md
@@ -1,0 +1,34 @@
+# Derelict Renderer
+
+A minimal Canvas2D renderer for Derelict board states. The renderer takes a
+`BoardState`, a sprite manifest and viewport information and draws everything
+onto a `CanvasRenderingContext2D` or `OffscreenCanvasRenderingContext2D`.
+
+## Usage
+
+```ts
+import { createRenderer } from './renderer';
+import { loadSpriteManifestFromText } from './manifest';
+
+const renderer = createRenderer();
+renderer.setSpriteManifest(loadSpriteManifestFromText(manifestText));
+renderer.setAssetResolver((key) => myImageCache[key]);
+renderer.resize(canvas.width, canvas.height);
+renderer.render(ctx, boardState, viewport);
+```
+
+## Manifest format
+
+Sprite manifests are provided as plain text, one entry per line:
+
+```
+string_id file_name x y width height layer xoff yoff
+```
+
+* Lines starting with `#` and blank lines are ignored.
+* `string_id` is used as the sprite key. Integer-like values represent cell
+  types; other strings represent token types.
+* `x=y=w=h=0` means the whole image is used.
+* All numeric fields must be integers. Negative offsets are allowed.
+* Duplicate keys are allowed; the last entry wins.
+```

--- a/Derelict/Renderer/package.json
+++ b/Derelict/Renderer/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "derelict-renderer",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test dist/tests"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "@types/node": "^18.0.0"
+  }
+}

--- a/Derelict/Renderer/src/assets.ts
+++ b/Derelict/Renderer/src/assets.ts
@@ -1,0 +1,5 @@
+export type AssetResolver = (
+  key: string
+) => HTMLImageElement | ImageBitmap | undefined;
+
+export const defaultAssetResolver: AssetResolver = () => undefined;

--- a/Derelict/Renderer/src/manifest.ts
+++ b/Derelict/Renderer/src/manifest.ts
@@ -1,0 +1,37 @@
+import type { SpriteEntry, SpriteManifest } from './types.js';
+
+export function loadSpriteManifestFromText(text: string): SpriteManifest {
+  const lines = text.split(/\r?\n/);
+  const map = new Map<string, SpriteEntry>();
+  lines.forEach((raw, idx) => {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) return;
+    const parts = line.split(/\s+/);
+    if (parts.length !== 9) {
+      throw new Error(`Invalid field count on line ${idx + 1}`);
+    }
+    const [key, file, x, y, w, h, layer, xoff, yoff] = parts;
+    const nums = [x, y, w, h, layer, xoff, yoff].map((n) => {
+      const val = parseInt(n, 10);
+      if (Number.isNaN(val)) {
+        throw new Error(`Invalid integer on line ${idx + 1}`);
+      }
+      return val;
+    });
+    const entry: SpriteEntry = {
+      key,
+      file,
+      x: nums[0],
+      y: nums[1],
+      w: nums[2],
+      h: nums[3],
+      layer: nums[4],
+      xoff: nums[5],
+      yoff: nums[6],
+    };
+    map.set(key, entry);
+  });
+  return { entries: [...map.values()] };
+}
+
+export type { SpriteEntry, SpriteManifest };

--- a/Derelict/Renderer/src/math.ts
+++ b/Derelict/Renderer/src/math.ts
@@ -1,0 +1,28 @@
+import type { Viewport } from './types.js';
+
+export function boardToScreen(
+  cell: { x: number; y: number },
+  vp: Viewport
+): { x: number; y: number; width: number; height: number } {
+  const sizePx = vp.cellSize * (vp.scale || 1);
+  return {
+    x: (cell.x - vp.origin.x) * sizePx,
+    y: (cell.y - vp.origin.y) * sizePx,
+    width: sizePx,
+    height: sizePx,
+  };
+}
+
+export function isCellVisible(
+  cell: { x: number; y: number },
+  vp: Viewport,
+  canvasPx: { w: number; h: number }
+): boolean {
+  const rect = boardToScreen(cell, vp);
+  return (
+    rect.x + rect.width > 0 &&
+    rect.y + rect.height > 0 &&
+    rect.x < canvasPx.w &&
+    rect.y < canvasPx.h
+  );
+}

--- a/Derelict/Renderer/src/renderer.ts
+++ b/Derelict/Renderer/src/renderer.ts
@@ -1,0 +1,165 @@
+import { loadSpriteManifestFromText } from './manifest.js';
+import { boardToScreen, isCellVisible } from './math.js';
+import { defaultAssetResolver, type AssetResolver } from './assets.js';
+import type {
+  Renderer,
+  SpriteManifest,
+  Viewport,
+  RenderOptions,
+  BoardState,
+} from './types.js';
+
+export function createRenderer(): Renderer {
+  let manifest: SpriteManifest = { entries: [] };
+  let resolver: AssetResolver = defaultAssetResolver;
+  let canvasPx = { w: 0, h: 0 };
+
+  function setSpriteManifest(m: SpriteManifest) {
+    manifest = m;
+  }
+
+  function loadSpriteManifestFromTextLocal(text: string) {
+    manifest = loadSpriteManifestFromText(text);
+  }
+
+  function setAssetResolver(r: AssetResolver) {
+    resolver = r;
+  }
+
+  function resize(widthPx: number, heightPx: number) {
+    canvasPx = { w: widthPx, h: heightPx };
+  }
+
+  function render(
+    ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+    state: BoardState,
+    viewport: Viewport,
+    options?: RenderOptions
+  ): void {
+    const dpr = viewport.dpr || 1;
+    const canvas = ctx.canvas as HTMLCanvasElement | OffscreenCanvas;
+    if (canvas) {
+      if (canvas.width !== canvasPx.w * dpr) canvas.width = canvasPx.w * dpr;
+      if (canvas.height !== canvasPx.h * dpr) canvas.height = canvasPx.h * dpr;
+    }
+
+    ctx.save();
+    ctx.scale(dpr, dpr);
+
+    if (options?.clear !== false) {
+      if (options?.background !== undefined) {
+        if (options.background !== null) {
+          ctx.fillStyle = options.background;
+          ctx.fillRect(0, 0, canvasPx.w, canvasPx.h);
+        } else {
+          ctx.clearRect(0, 0, canvasPx.w, canvasPx.h);
+        }
+      } else {
+        ctx.clearRect(0, 0, canvasPx.w, canvasPx.h);
+      }
+    }
+
+    const entryMap = new Map<string, typeof manifest.entries[number]>();
+    for (const e of manifest.entries) entryMap.set(e.key, e);
+
+    const drawCalls: { layer: number; fn: () => void }[] = [];
+
+    // Terrain drawing omitted unless getCellType available.
+    const getCellType = (state as any).getCellType as
+      | ((cell: { x: number; y: number }) => number)
+      | undefined;
+    if (getCellType) {
+      for (let y = 0; y < state.size; y++) {
+        for (let x = 0; x < state.size; x++) {
+          const type = getCellType({ x, y });
+          if (type < 0) continue;
+          const sprite = entryMap.get(String(type));
+          if (!sprite) continue;
+          const cell = { x, y };
+          if (!isCellVisible(cell, viewport, canvasPx)) continue;
+          const rect = boardToScreen(cell, viewport);
+          const image = resolver(sprite.file);
+          const draw = () => {
+            ctx.save();
+            ctx.translate(rect.x, rect.y);
+            const img = image;
+            if (img) {
+              const sw = sprite.w || (img as any).width || rect.width;
+              const sh = sprite.h || (img as any).height || rect.height;
+              ctx.drawImage(
+                img as any,
+                sprite.x,
+                sprite.y,
+                sw,
+                sh,
+                0,
+                0,
+                rect.width,
+                rect.height
+              );
+            } else {
+              ctx.fillStyle = 'magenta';
+              ctx.fillRect(0, 0, rect.width, rect.height);
+            }
+            ctx.restore();
+          };
+          drawCalls.push({ layer: sprite.layer, fn: draw });
+        }
+      }
+    }
+
+    for (const token of state.tokens) {
+      const sprite = entryMap.get(token.type);
+      for (const cell of token.cells) {
+        if (!isCellVisible(cell, viewport, canvasPx)) continue;
+        const rect = boardToScreen(cell, viewport);
+        const image = sprite ? resolver(sprite.file) : undefined;
+        const draw = () => {
+          ctx.save();
+          ctx.translate(rect.x + rect.width / 2, rect.y + rect.height / 2);
+          if (sprite) {
+            ctx.translate(sprite.xoff, sprite.yoff);
+          }
+          if (token.rot) {
+            ctx.rotate((token.rot * Math.PI) / 180);
+          }
+          if (image && sprite) {
+            const sw = sprite.w || (image as any).width || rect.width;
+            const sh = sprite.h || (image as any).height || rect.height;
+            ctx.drawImage(
+              image as any,
+              sprite.x,
+              sprite.y,
+              sw,
+              sh,
+              -sw / 2,
+              -sh / 2,
+              sw,
+              sh
+            );
+          } else {
+            ctx.fillStyle = 'magenta';
+            ctx.fillRect(-rect.width / 2, -rect.height / 2, rect.width, rect.height);
+          }
+          ctx.restore();
+        };
+        drawCalls.push({ layer: sprite?.layer ?? 0, fn: draw });
+      }
+    }
+
+    drawCalls.sort((a, b) => a.layer - b.layer);
+    for (const d of drawCalls) d.fn();
+
+    ctx.restore();
+  }
+
+  return {
+    setSpriteManifest,
+    loadSpriteManifestFromText: loadSpriteManifestFromTextLocal,
+    setAssetResolver,
+    resize,
+    render,
+    boardToScreen,
+    isCellVisible,
+  };
+}

--- a/Derelict/Renderer/src/types.ts
+++ b/Derelict/Renderer/src/types.ts
@@ -1,0 +1,67 @@
+import type { AssetResolver } from './assets.js';
+
+export interface Viewport {
+  origin: { x: number; y: number };
+  scale: number;
+  cellSize: number;
+  dpr?: number;
+}
+
+export interface RenderOptions {
+  clear?: boolean;
+  background?: string | null;
+  showSegmentBounds?: boolean;
+}
+
+export interface BoardState {
+  size: number;
+  segments: {
+    instanceId: string;
+    segmentId: string;
+    origin: { x: number; y: number };
+    rot: 0 | 90 | 180 | 270;
+  }[];
+  tokens: {
+    tokenId: string;
+    type: string;
+    rot: 0 | 90 | 180 | 270;
+    cells: { x: number; y: number }[];
+    attrs?: Record<string, unknown>;
+  }[];
+}
+
+export interface Renderer {
+  setSpriteManifest(manifest: SpriteManifest): void;
+  loadSpriteManifestFromText(text: string): void;
+  setAssetResolver(resolver: AssetResolver): void;
+  resize(widthPx: number, heightPx: number): void;
+  render(
+    ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+    state: BoardState,
+    viewport: Viewport,
+    options?: RenderOptions
+  ): void;
+
+  boardToScreen(
+    cell: { x: number; y: number },
+    vp: Viewport
+  ): { x: number; y: number; width: number; height: number };
+
+  isCellVisible(
+    cell: { x: number; y: number },
+    vp: Viewport,
+    canvasPx: { w: number; h: number }
+  ): boolean;
+}
+
+export type { AssetResolver };
+export interface SpriteEntry {
+  key: string; // integer-like string -> cellType, otherwise token type
+  file: string; // image path or atlas key
+  x: number; y: number; // source rect top-left in pixels
+  w: number; h: number; // source rect size in pixels; 0,0,0,0 => whole image
+  layer: number; // draw order (lower first)
+  xoff: number; yoff: number; // pixel offsets from cell center BEFORE rotation
+}
+export interface SpriteManifest { entries: SpriteEntry[]; }
+export declare function createRenderer(): Renderer;

--- a/Derelict/Renderer/tests/manifest.test.ts
+++ b/Derelict/Renderer/tests/manifest.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { loadSpriteManifestFromText } from '../src/manifest.js';
+
+test('manifest parsing: parses valid lines and ignores comments/blank', () => {
+  const text = `# comment\n\n1 grass.png 0 0 0 0 0 0 0\nfoo token.png 1 2 3 4 5 6 7`;
+  const manifest = loadSpriteManifestFromText(text);
+  assert.equal(manifest.entries.length, 2);
+  assert.equal(manifest.entries[0].key, '1');
+  assert.equal(manifest.entries[1].key, 'foo');
+});
+
+test('manifest parsing: bad field count throws with line number', () => {
+  const text = `1 a.png 0 0 0 0 0 0`; // only 8 fields
+  assert.throws(() => loadSpriteManifestFromText(text), /line 1/);
+});
+
+test('manifest parsing: non-integer numeric fields throw', () => {
+  const text = `1 a.png 0 0 0 nope 0 0 0`;
+  assert.throws(() => loadSpriteManifestFromText(text), /line 1/);
+});
+
+test('manifest parsing: last write wins for duplicate keys', () => {
+  const text = `1 a.png 0 0 0 0 0 0 0\n1 b.png 1 1 1 1 1 1 1`;
+  const manifest = loadSpriteManifestFromText(text);
+  assert.equal(manifest.entries.length, 1);
+  assert.equal(manifest.entries[0].file, 'b.png');
+  assert.equal(manifest.entries[0].x, 1);
+});

--- a/Derelict/Renderer/tests/math.test.ts
+++ b/Derelict/Renderer/tests/math.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { boardToScreen, isCellVisible } from '../src/math.js';
+import type { Viewport } from '../src/types.js';
+
+test('boardToScreen maps correctly with scale and origin', () => {
+  const vp: Viewport = { origin: { x: 1, y: 2 }, scale: 2, cellSize: 16 };
+  const rect = boardToScreen({ x: 3, y: 4 }, vp);
+  assert.deepEqual(rect, { x: 64, y: 64, width: 32, height: 32 });
+});
+
+test('isCellVisible inside and outside bounds', () => {
+  const vp: Viewport = { origin: { x: 0, y: 0 }, scale: 1, cellSize: 32 };
+  const canvasPx = { w: 64, h: 64 };
+  assert.equal(isCellVisible({ x: 1, y: 1 }, vp, canvasPx), true);
+  assert.equal(isCellVisible({ x: -1, y: 0 }, vp, canvasPx), false);
+  assert.equal(isCellVisible({ x: 2, y: 0 }, vp, canvasPx), false);
+});

--- a/Derelict/Renderer/tests/renderer.test.ts
+++ b/Derelict/Renderer/tests/renderer.test.ts
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRenderer } from '../src/renderer.js';
+import { loadSpriteManifestFromText } from '../src/manifest.js';
+import type { BoardState, Viewport } from '../src/types.js';
+
+function makeCtx() {
+  const calls: Record<string, any[]> = {
+    drawImage: [],
+    translate: [],
+    rotate: [],
+    save: [],
+    restore: [],
+    fillRect: [],
+    clearRect: [],
+  };
+  let _fillStyle = '';
+  const ctx: any = {
+    canvas: { width: 0, height: 0 },
+    get fillStyle() {
+      return _fillStyle;
+    },
+    set fillStyle(v: string) {
+      _fillStyle = v;
+      calls.fillStyle = calls.fillStyle || [];
+      calls.fillStyle.push(v);
+    },
+    save: () => calls.save.push([]),
+    restore: () => calls.restore.push([]),
+    translate: (...a: any[]) => calls.translate.push(a),
+    rotate: (r: number) => calls.rotate.push(r),
+    drawImage: (...a: any[]) => calls.drawImage.push(a),
+    fillRect: (...a: any[]) => calls.fillRect.push(a),
+    clearRect: (...a: any[]) => calls.clearRect.push(a),
+    scale: () => {},
+  };
+  return { ctx, calls };
+}
+
+const manifestText = `foo foo.png 0 0 0 0 0 1 2`;
+const manifest = loadSpriteManifestFromText(manifestText);
+
+const state: BoardState = {
+  size: 10,
+  segments: [],
+  tokens: [
+    { tokenId: 't1', type: 'foo', rot: 90, cells: [{ x: 0, y: 0 }] },
+    { tokenId: 't2', type: 'missing', rot: 0, cells: [{ x: 1, y: 1 }] },
+    { tokenId: 't3', type: 'foo', rot: 0, cells: [{ x: 100, y: 100 }] },
+  ],
+};
+
+const viewport: Viewport = {
+  origin: { x: 0, y: 0 },
+  scale: 1,
+  cellSize: 32,
+};
+
+test('renderer handles missing sprites with fallback', () => {
+  const renderer = createRenderer();
+  renderer.setSpriteManifest(manifest);
+  renderer.setAssetResolver(() => ({ width: 1, height: 1 } as any));
+  renderer.resize(64, 64);
+  const { ctx, calls } = makeCtx();
+  renderer.render(ctx as any, state, viewport);
+  // missing sprite should set fillStyle to magenta
+  assert.ok(calls.fillStyle.includes('magenta'));
+});
+
+test('renderer culls off-screen cells', () => {
+  const renderer = createRenderer();
+  renderer.setSpriteManifest(manifest);
+  renderer.setAssetResolver(() => ({ width: 1, height: 1 } as any));
+  renderer.resize(64, 64);
+  const { ctx, calls } = makeCtx();
+  renderer.render(ctx as any, state, viewport);
+  // only first two tokens are in viewport; third is off-screen
+  assert.equal(calls.drawImage.length, 1); // only visible sprite
+});
+
+test('renderer applies token offsets and rotation', () => {
+  const renderer = createRenderer();
+  renderer.setSpriteManifest(manifest);
+  renderer.setAssetResolver(() => ({ width: 1, height: 1 } as any));
+  renderer.resize(64, 64);
+  const { ctx, calls } = makeCtx();
+  renderer.render(ctx as any, state, viewport);
+  // translate called for cell center and for xoff/yoff
+  const translateCalls = calls.translate;
+  // second translate for offset
+  const offsetCall = translateCalls.find((c) => c[0] === 1 && c[1] === 2);
+  assert.ok(offsetCall);
+  // rotation applied once with 90 degrees
+  assert.equal(
+    calls.rotate.some((r) => Math.abs(r - Math.PI / 2) < 1e-6),
+    true
+  );
+});
+
+const hasOffscreen = typeof OffscreenCanvas !== 'undefined';
+const offscreenTest = hasOffscreen ? test : test.skip;
+offscreenTest('renderer smoke test with OffscreenCanvas', () => {
+  const renderer = createRenderer();
+  renderer.setSpriteManifest(manifest);
+  renderer.setAssetResolver(() => {
+    const c = new OffscreenCanvas(1, 1);
+    const ictx = c.getContext('2d');
+    ictx!.fillStyle = 'white';
+    ictx!.fillRect(0, 0, 1, 1);
+    return c.transferToImageBitmap();
+  });
+  renderer.resize(64, 64);
+  const canvas = new OffscreenCanvas(64, 64);
+  const ctx = canvas.getContext('2d')!;
+  renderer.render(ctx, state, viewport);
+  const img1 = ctx.getImageData(0, 0, 64, 64).data;
+  renderer.render(ctx, state, viewport);
+  const img2 = ctx.getImageData(0, 0, 64, 64).data;
+  assert.deepEqual(Array.from(img1), Array.from(img2));
+});

--- a/Derelict/Renderer/tsconfig.json
+++ b/Derelict/Renderer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- implement sprite manifest parser, math helpers, and canvas renderer
- add tests for manifest parsing, math helpers, and renderer behaviour using node:test
- document renderer usage and manifest format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a51d63424833394c39a313d81319a