### PR TITLE
feat(editor): add basic mission editor with core tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/Derelict/Editor/README.md
+++ b/Derelict/Editor/README.md
@@ -1,0 +1,20 @@
+# Derelict Editor
+
+A minimal browser-based mission editor for the Derelict game. This package only
+contains the bare pieces required for tests: a pure `EditorCore`, basic DOM
+wiring through `EditorUI`, geometry helpers and a small ghost overlay renderer.
+
+## Development
+
+```sh
+npm install
+npm test
+```
+
+The tests use the Node `node:test` runner. DOM based tests run inside jsdom.
+
+## Usage
+
+`createEditor(container, renderer, boardStateApi, initialState)` will build the
+editor in the given container element. Rendering and board state logic are
+provided by the caller via the lightweight interfaces in `src/types.ts`.

--- a/Derelict/Editor/package.json
+++ b/Derelict/Editor/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "derelict-editor",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test dist/tests"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "@types/node": "^18.0.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/Derelict/Editor/src/adapters/BoardStateAdapter.ts
+++ b/Derelict/Editor/src/adapters/BoardStateAdapter.ts
@@ -1,0 +1,52 @@
+import type { BoardState, BoardStateAPI } from '../types.js';
+
+export class BoardStateAdapter {
+  constructor(private api: BoardStateAPI, private state: BoardState) {}
+
+  getState() {
+    return this.state;
+  }
+
+  newBoard(size: number, segLibText: string, tokenLibText: string) {
+    this.state = this.api.newBoard(size, segLibText, tokenLibText);
+    return this.state;
+  }
+
+  addSegment(seg: {
+    instanceId: string;
+    segmentId: string;
+    origin: { x: number; y: number };
+    rot: 0 | 90 | 180 | 270;
+  }) {
+    this.api.addSegment(this.state, seg);
+  }
+  updateSegment(id: string, patch: Partial<any>) {
+    this.api.updateSegment(this.state, id, patch);
+  }
+  removeSegment(id: string) {
+    this.api.removeSegment(this.state, id);
+  }
+  addToken(tok: {
+    tokenId: string;
+    type: string;
+    rot: 0 | 90 | 180 | 270;
+    cells: { x: number; y: number }[];
+  }) {
+    this.api.addToken(this.state, tok);
+  }
+  updateToken(id: string, patch: Partial<any>) {
+    this.api.updateToken(this.state, id, patch);
+  }
+  removeToken(id: string) {
+    this.api.removeToken(this.state, id);
+  }
+  importMission(text: string) {
+    this.api.importMission(this.state, text);
+  }
+  exportMission() {
+    return this.api.exportMission(this.state);
+  }
+  getCellType(coord: { x: number; y: number }) {
+    return this.api.getCellType(this.state, coord);
+  }
+}

--- a/Derelict/Editor/src/adapters/RendererAdapter.ts
+++ b/Derelict/Editor/src/adapters/RendererAdapter.ts
@@ -1,0 +1,13 @@
+import type { Renderer, BoardState } from '../types.js';
+
+export class RendererAdapter {
+  constructor(private renderer: Renderer) {}
+
+  loadManifest(text: string) {
+    this.renderer.loadSpriteManifestFromText(text);
+  }
+
+  render(ctx: CanvasRenderingContext2D, state: BoardState) {
+    this.renderer.render(ctx, state, { x: 0, y: 0 });
+  }
+}

--- a/Derelict/Editor/src/editor/EditorCore.ts
+++ b/Derelict/Editor/src/editor/EditorCore.ts
@@ -1,0 +1,106 @@
+import type { BoardState, BoardStateAPI, EditorState, GhostKind } from '../types.js';
+
+function nextRot(rot: 0 | 90 | 180 | 270, dir: 1 | -1): 0 | 90 | 180 | 270 {
+  const r = (rot + dir * 90 + 360) % 360;
+  return r as 0 | 90 | 180 | 270;
+}
+
+export class EditorCore {
+  private _ui: EditorState = { selected: null, ghost: null };
+
+  constructor(private api: BoardStateAPI, private state: BoardState) {}
+
+  get ui(): Readonly<EditorState> {
+    return JSON.parse(JSON.stringify(this._ui));
+  }
+
+  getState(): BoardState {
+    return this.state;
+  }
+
+  selectSegment(segmentId: string): void {
+    this._ui.selected = null;
+    this._ui.ghost = {
+      kind: 'segment',
+      id: segmentId,
+      rot: 0,
+      cell: null,
+    };
+  }
+
+  selectToken(tokenType: string): void {
+    this._ui.selected = null;
+    this._ui.ghost = {
+      kind: 'token',
+      id: tokenType,
+      rot: 0,
+      cell: null,
+    };
+  }
+
+  clearSelection(): void {
+    this._ui.selected = null;
+    this._ui.ghost = null;
+  }
+
+  setGhostCell(cell: { x: number; y: number } | null): void {
+    if (this._ui.ghost) this._ui.ghost.cell = cell;
+  }
+
+  rotateGhost(dir: 1 | -1): void {
+    if (this._ui.ghost) {
+      this._ui.ghost.rot = nextRot(this._ui.ghost.rot, dir);
+    }
+  }
+
+  placeGhost(): { ok: true } | { ok: false; error: string } {
+    const g = this._ui.ghost;
+    if (!g || !g.cell) return { ok: false, error: 'no-ghost' };
+    try {
+      if (g.kind === 'segment') {
+        const id = `seg-${Date.now()}`;
+        this.api.addSegment(this.state, {
+          instanceId: id,
+          segmentId: g.id,
+          origin: g.cell,
+          rot: g.rot,
+        });
+        this._ui.selected = { kind: 'segment', id };
+      } else if (g.kind === 'token') {
+        const id = `tok-${Date.now()}`;
+        this.api.addToken(this.state, {
+          tokenId: id,
+          type: g.id,
+          rot: g.rot,
+          cells: [g.cell],
+        });
+        this._ui.selected = { kind: 'token', id };
+      }
+      return { ok: true };
+    } catch (e: any) {
+      return { ok: false, error: String(e.message || e) };
+    }
+  }
+
+  deleteSelection(): void {
+    const sel = this._ui.selected;
+    if (!sel) return;
+    if (sel.kind === 'segment') this.api.removeSegment(this.state, sel.id);
+    else this.api.removeToken(this.state, sel.id);
+    this.clearSelection();
+  }
+
+  newMission(name: string, size: number, segLibText: string, tokenLibText: string): void {
+    this.state = this.api.newBoard(size, segLibText, tokenLibText);
+    this.clearSelection();
+  }
+
+  loadMission(text: string): void {
+    this.api.importMission(this.state, text);
+    this.clearSelection();
+  }
+
+  saveMission(): string {
+    return this.api.exportMission(this.state);
+  }
+}

--- a/Derelict/Editor/src/editor/EditorUI.ts
+++ b/Derelict/Editor/src/editor/EditorUI.ts
@@ -1,0 +1,84 @@
+import layout from './layout.html.js';
+import { EditorCore } from './EditorCore.js';
+import { GhostOverlay } from './GhostOverlay.js';
+import { qs, createEl } from '../util/dom.js';
+import { pixelToCell, clampCell } from '../util/geometry.js';
+import { registerShortcuts } from './Shortcuts.js';
+import type { Renderer, BoardState } from '../types.js';
+
+export class EditorUI {
+  private viewport: HTMLCanvasElement;
+  private overlay: HTMLCanvasElement;
+  private overlayDrawer: GhostOverlay;
+  private segPalette: HTMLElement;
+
+  constructor(
+    private container: HTMLElement,
+    private core: EditorCore,
+    private renderer: Renderer,
+  ) {
+    container.innerHTML = layout;
+    this.viewport = qs<HTMLCanvasElement>(container, '#viewport');
+    this.overlay = qs<HTMLCanvasElement>(container, '#overlay');
+    this.segPalette = qs<HTMLElement>(container, '#segment-palette');
+    this.overlayDrawer = new GhostOverlay(this.overlay);
+    this.populatePalettes();
+    this.wireEvents();
+  }
+
+  private populatePalettes() {
+    const state = this.core.getState();
+    for (const seg of state.segmentDefs) {
+      const li = createEl('li');
+      li.textContent = seg.name || seg.segmentId;
+      li.dataset['seg'] = seg.segmentId;
+      li.addEventListener('click', () => {
+        this.core.selectSegment(seg.segmentId);
+        this.drawGhost();
+      });
+      this.segPalette.appendChild(li);
+    }
+  }
+
+  private wireEvents() {
+    this.viewport.addEventListener('mousemove', (ev) => {
+      const rect = this.viewport.getBoundingClientRect();
+      const cell = pixelToCell({ x: ev.clientX - rect.left, y: ev.clientY - rect.top });
+      const clamped = clampCell(cell, this.core.getState().size);
+      this.core.setGhostCell(clamped);
+      this.drawGhost();
+    });
+    this.viewport.addEventListener('click', () => {
+      const res = this.core.placeGhost();
+      if (res.ok) this.render();
+    });
+
+    registerShortcuts(document, {
+      rotate: (d) => {
+        this.core.rotateGhost(d);
+        this.drawGhost();
+      },
+      unselect: () => {
+        this.core.clearSelection();
+        this.drawGhost();
+      },
+      delete: () => {
+        this.core.deleteSelection();
+        this.render();
+      },
+      save: () => {
+        this.core.saveMission();
+      },
+    });
+  }
+
+  drawGhost() {
+    this.overlayDrawer.draw(this.core.ui.ghost || null);
+  }
+
+  render() {
+    const ctx = this.viewport.getContext('2d');
+    if (ctx) this.renderer.render(ctx, this.core.getState(), { x: 0, y: 0 });
+    this.drawGhost();
+  }
+}

--- a/Derelict/Editor/src/editor/GhostOverlay.ts
+++ b/Derelict/Editor/src/editor/GhostOverlay.ts
@@ -1,0 +1,29 @@
+import type { EditorState } from '../types.js';
+
+export class GhostOverlay {
+  private ctx: CanvasRenderingContext2D;
+  constructor(private canvas: HTMLCanvasElement, private tileSize = 32) {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('no ctx');
+    this.ctx = ctx;
+  }
+
+  clear() {
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+
+  draw(ghost: EditorState['ghost'] | null): void {
+    this.clear();
+    if (!ghost || !ghost.cell) return;
+    this.ctx.save();
+    this.ctx.globalAlpha = 0.5;
+    const { x, y } = ghost.cell;
+    const ts = this.tileSize;
+    this.ctx.translate((x + 0.5) * ts, (y + 0.5) * ts);
+    this.ctx.rotate((ghost.rot * Math.PI) / 180);
+    this.ctx.translate(-ts / 2, -ts / 2);
+    this.ctx.fillStyle = 'rgba(0,0,255,0.5)';
+    this.ctx.fillRect(0, 0, ts, ts);
+    this.ctx.restore();
+  }
+}

--- a/Derelict/Editor/src/editor/Shortcuts.ts
+++ b/Derelict/Editor/src/editor/Shortcuts.ts
@@ -1,0 +1,23 @@
+export interface ShortcutHandlers {
+  rotate?: (dir: 1 | -1) => void;
+  unselect?: () => void;
+  save?: () => void;
+  delete?: () => void;
+}
+
+export function registerShortcuts(target: HTMLElement | Document, h: ShortcutHandlers) {
+  (target as any).addEventListener('keydown', (ev: KeyboardEvent) => {
+    if (ev.key === 'r' || ev.key === 'R') {
+      h.rotate?.(ev.shiftKey ? -1 : 1);
+      ev.preventDefault();
+    } else if (ev.key === 'Escape') {
+      h.unselect?.();
+    } else if (ev.key === 'Delete' || ev.key === 'Backspace') {
+      h.delete?.();
+      ev.preventDefault();
+    } else if ((ev.ctrlKey || ev.metaKey) && ev.key === 's') {
+      h.save?.();
+      ev.preventDefault();
+    }
+  });
+}

--- a/Derelict/Editor/src/editor/layout.html.ts
+++ b/Derelict/Editor/src/editor/layout.html.ts
@@ -1,0 +1,24 @@
+const layout = `
+<div id="top-bar">Derelict Game Editor</div>
+<div id="buttons1">
+  <button id="btn-new">New</button>
+  <button id="btn-load">Load</button>
+  <button id="btn-save">Save</button>
+  <button id="btn-play">Play</button>
+</div>
+<div id="main">
+  <canvas id="viewport" width="640" height="480"></canvas>
+  <canvas id="overlay" width="640" height="480" style="position:absolute;left:0;top:0;"></canvas>
+  <ul id="segment-palette"></ul>
+</div>
+<div id="buttons2">
+  <button id="rot-left">Rotate Left</button>
+  <button id="rot-right">Rotate Right</button>
+  <button id="unselect">Unselect</button>
+  <button id="place">Place</button>
+  <button id="delete">Delete</button>
+  <button id="edit-mission">Edit Mission Data</button>
+</div>
+<div id="token-palette"></div>
+`;
+export default layout;

--- a/Derelict/Editor/src/editor/styles.css
+++ b/Derelict/Editor/src/editor/styles.css
@@ -1,0 +1,2 @@
+#top-bar { text-align:center; font-weight:bold; }
+#segment-palette { list-style:none; }

--- a/Derelict/Editor/src/index.ts
+++ b/Derelict/Editor/src/index.ts
@@ -1,0 +1,14 @@
+import type { Renderer, BoardStateAPI, BoardState } from './types.js';
+import { EditorCore } from './editor/EditorCore.js';
+import { EditorUI } from './editor/EditorUI.js';
+
+export function createEditor(
+  container: HTMLElement,
+  renderer: Renderer,
+  api: BoardStateAPI,
+  state: BoardState,
+) {
+  const core = new EditorCore(api, state);
+  const ui = new EditorUI(container, core, renderer);
+  return { core, ui };
+}

--- a/Derelict/Editor/src/types.ts
+++ b/Derelict/Editor/src/types.ts
@@ -1,0 +1,63 @@
+export interface Renderer {
+  setSpriteManifest(manifest: { entries: any[] }): void;
+  loadSpriteManifestFromText(text: string): void;
+  setAssetResolver(
+    resolver: (key: string) => HTMLImageElement | ImageBitmap | undefined,
+  ): void;
+  resize(w: number, h: number): void;
+  render(
+    ctx: CanvasRenderingContext2D,
+    state: BoardState,
+    vp: any,
+    opt?: any,
+  ): void;
+}
+
+export interface BoardState {
+  size: number;
+  segmentDefs: { segmentId: string; name: string }[];
+  tokenTypes: { type: string }[];
+  segments: any[];
+  tokens: any[];
+}
+
+export interface BoardStateAPI {
+  newBoard(size: number, segLibText: string, tokenLibText: string): BoardState;
+  addSegment(
+    state: BoardState,
+    seg: {
+      instanceId: string;
+      segmentId: string;
+      origin: { x: number; y: number };
+      rot: 0 | 90 | 180 | 270;
+    },
+  ): void;
+  updateSegment(state: BoardState, id: string, patch: Partial<any>): void;
+  removeSegment(state: BoardState, id: string): void;
+  addToken(
+    state: BoardState,
+    tok: {
+      tokenId: string;
+      type: string;
+      rot: 0 | 90 | 180 | 270;
+      cells: { x: number; y: number }[];
+    },
+  ): void;
+  updateToken(state: BoardState, id: string, patch: Partial<any>): void;
+  removeToken(state: BoardState, id: string): void;
+  importMission(state: BoardState, text: string): void;
+  exportMission(state: BoardState): string;
+  getCellType(state: BoardState, coord: { x: number; y: number }): number | -1;
+}
+
+export type GhostKind = 'segment' | 'token' | null;
+
+export interface EditorState {
+  selected?: { kind: 'segment' | 'token'; id: string } | null;
+  ghost?: {
+    kind: GhostKind;
+    id: string;
+    rot: 0 | 90 | 180 | 270;
+    cell: { x: number; y: number } | null;
+  } | null;
+}

--- a/Derelict/Editor/src/types/external.d.ts
+++ b/Derelict/Editor/src/types/external.d.ts
@@ -1,0 +1,9 @@
+declare module 'jsdom';
+declare module 'node:test' {
+  export const describe: any;
+  export const it: any;
+}
+declare module 'node:assert/strict' {
+  const assert: any;
+  export default assert;
+}

--- a/Derelict/Editor/src/util/dom.ts
+++ b/Derelict/Editor/src/util/dom.ts
@@ -1,0 +1,11 @@
+export function qs<T extends Element>(root: ParentNode, sel: string): T {
+  const el = root.querySelector(sel) as T | null;
+  if (!el) throw new Error(`Missing element ${sel}`);
+  return el;
+}
+
+export function createEl<K extends keyof HTMLElementTagNameMap>(tag: K, className?: string) {
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  return el;
+}

--- a/Derelict/Editor/src/util/files.ts
+++ b/Derelict/Editor/src/util/files.ts
@@ -1,0 +1,18 @@
+export function readFileAsText(f: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => resolve(String(reader.result));
+    reader.readAsText(f);
+  });
+}
+
+export function downloadText(name: string, text: string) {
+  const blob = new Blob([text], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/Derelict/Editor/src/util/geometry.ts
+++ b/Derelict/Editor/src/util/geometry.ts
@@ -1,0 +1,16 @@
+export const TILE_SIZE = 32;
+
+export function cellToPixel(cell: { x: number; y: number }) {
+  return { x: cell.x * TILE_SIZE, y: cell.y * TILE_SIZE };
+}
+
+export function pixelToCell(pos: { x: number; y: number }) {
+  return { x: Math.floor(pos.x / TILE_SIZE), y: Math.floor(pos.y / TILE_SIZE) };
+}
+
+export function clampCell(cell: { x: number; y: number }, size: number) {
+  return {
+    x: Math.min(Math.max(0, cell.x), size - 1),
+    y: Math.min(Math.max(0, cell.y), size - 1),
+  };
+}

--- a/Derelict/Editor/tests/core.test.ts
+++ b/Derelict/Editor/tests/core.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { EditorCore } from '../src/editor/EditorCore.js';
+import type { BoardState, BoardStateAPI } from '../src/types.js';
+
+function makeState(): BoardState {
+  return {
+    size: 10,
+    segmentDefs: [{ segmentId: 'segA', name: 'SegA' }],
+    tokenTypes: [{ type: 'tokA' }],
+    segments: [],
+    tokens: [],
+  };
+}
+
+describe('EditorCore basics', () => {
+  it('selecting and clearing', () => {
+    const api: BoardStateAPI = {
+      newBoard: () => makeState(),
+      addSegment: () => {},
+      updateSegment: () => {},
+      removeSegment: () => {},
+      addToken: () => {},
+      updateToken: () => {},
+      removeToken: () => {},
+      importMission: () => {},
+      exportMission: () => 'text',
+      getCellType: () => -1,
+    };
+    const core = new EditorCore(api, makeState());
+    core.selectSegment('segA');
+    assert.equal(core.ui.ghost?.kind, 'segment');
+    core.clearSelection();
+    assert.equal(core.ui.ghost, null);
+  });
+
+  it('rotate ghost cycles', () => {
+    const api: any = { newBoard: () => makeState() };
+    const core = new EditorCore(api, makeState());
+    core.selectSegment('segA');
+    core.rotateGhost(1);
+    assert.equal(core.ui.ghost?.rot, 90);
+    core.rotateGhost(1);
+    core.rotateGhost(1);
+    core.rotateGhost(1);
+    assert.equal(core.ui.ghost?.rot, 0);
+    core.rotateGhost(-1);
+    assert.equal(core.ui.ghost?.rot, 270);
+  });
+
+  it('placeGhost adds via API', () => {
+    let added: any = null;
+    const api: BoardStateAPI = {
+      newBoard: () => makeState(),
+      addSegment: (_s, seg) => {
+        added = seg;
+      },
+      updateSegment: () => {},
+      removeSegment: () => {},
+      addToken: () => {},
+      updateToken: () => {},
+      removeToken: () => {},
+      importMission: () => {},
+      exportMission: () => 't',
+      getCellType: () => -1,
+    };
+    const core = new EditorCore(api, makeState());
+    core.selectSegment('segA');
+    core.setGhostCell({ x: 1, y: 2 });
+    const res = core.placeGhost();
+    assert.equal(res.ok, true);
+    assert.deepEqual(added.origin, { x: 1, y: 2 });
+  });
+
+  it('placeGhost handles API error', () => {
+    const api: BoardStateAPI = {
+      newBoard: () => makeState(),
+      addSegment: () => {
+        throw new Error('bad');
+      },
+      updateSegment: () => {},
+      removeSegment: () => {},
+      addToken: () => {},
+      updateToken: () => {},
+      removeToken: () => {},
+      importMission: () => {},
+      exportMission: () => 't',
+      getCellType: () => -1,
+    };
+    const core = new EditorCore(api, makeState());
+    core.selectSegment('segA');
+    core.setGhostCell({ x: 1, y: 1 });
+    const res = core.placeGhost();
+    assert.equal(res.ok, false);
+  });
+
+  it('deleteSelection delegates', () => {
+    let removed = '';
+    const api: BoardStateAPI = {
+      newBoard: () => makeState(),
+      addSegment: () => {},
+      updateSegment: () => {},
+      removeSegment: (_s, id) => {
+        removed = id;
+      },
+      addToken: () => {},
+      updateToken: () => {},
+      removeToken: () => {},
+      importMission: () => {},
+      exportMission: () => 't',
+      getCellType: () => -1,
+    };
+    const core = new EditorCore(api, makeState());
+    (core as any)._ui.selected = { kind: 'segment', id: 'abc' };
+    core.deleteSelection();
+    assert.equal(removed, 'abc');
+  });
+});

--- a/Derelict/Editor/tests/geometry.test.ts
+++ b/Derelict/Editor/tests/geometry.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { cellToPixel, pixelToCell, clampCell, TILE_SIZE } from '../src/util/geometry.js';
+
+describe('geometry helpers', () => {
+  it('cell to pixel and back', () => {
+    const cell = { x: 2, y: 3 };
+    const px = cellToPixel(cell);
+    assert.deepEqual(px, { x: 2 * TILE_SIZE, y: 3 * TILE_SIZE });
+    const back = pixelToCell(px);
+    assert.deepEqual(back, cell);
+  });
+
+  it('clampCell bounds', () => {
+    const clamped = clampCell({ x: -1, y: 12 }, 10);
+    assert.deepEqual(clamped, { x: 0, y: 9 });
+  });
+});

--- a/Derelict/Editor/tests/ghost.test.ts
+++ b/Derelict/Editor/tests/ghost.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { GhostOverlay } from '../src/editor/GhostOverlay.js';
+
+describe('GhostOverlay drawing', () => {
+  it('applies rotation and alpha', () => {
+    class Ctx {
+      ops: any[] = [];
+      _alpha = 1;
+      set globalAlpha(v: number) {
+        this._alpha = v;
+        this.ops.push(['alpha', v]);
+      }
+      get globalAlpha() {
+        return this._alpha;
+      }
+      clearRect() {
+        this.ops.push(['clear']);
+      }
+      save() {
+        this.ops.push(['save']);
+      }
+      restore() {
+        this.ops.push(['restore']);
+      }
+      translate(x: number, y: number) {
+        this.ops.push(['translate', x, y]);
+      }
+      rotate(a: number) {
+        this.ops.push(['rotate', a]);
+      }
+      fillRect(x: number, y: number, w: number, h: number) {
+        this.ops.push(['fillRect', x, y, w, h]);
+      }
+    }
+    const ctx = new Ctx();
+    const canvas: any = { width: 100, height: 100, getContext: () => ctx };
+    const overlay = new GhostOverlay(canvas, 32);
+    overlay.draw({ kind: 'segment', id: 's', rot: 90, cell: { x: 1, y: 2 } });
+    assert.deepEqual(ctx.ops[1], ['save']);
+    assert.deepEqual(ctx.ops[2], ['alpha', 0.5]);
+    assert.deepEqual(ctx.ops[3], ['translate', 48, 80]);
+    assert.equal(ctx.ops[4][0], 'rotate');
+    assert.ok(Math.abs(ctx.ops[4][1] - Math.PI / 2) < 1e-6);
+    assert.deepEqual(ctx.ops[5], ['translate', -16, -16]);
+    assert.ok(ctx.ops.some((o) => o[0] === 'fillRect'));
+  });
+});

--- a/Derelict/Editor/tests/ui.smoke.test.ts
+++ b/Derelict/Editor/tests/ui.smoke.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { EditorCore } from '../src/editor/EditorCore.js';
+import { EditorUI } from '../src/editor/EditorUI.js';
+import type { BoardState, BoardStateAPI, Renderer } from '../src/types.js';
+
+describe('EditorUI smoke test', () => {
+  it('segment palette and placement', () => {
+    const dom = new JSDOM(`<!doctype html><html><body><div id="app"></div></body></html>`, {
+      pretendToBeVisual: true,
+    });
+    const { window } = dom;
+    (globalThis as any).window = window;
+    (globalThis as any).document = window.document;
+    (window.HTMLCanvasElement.prototype as any).getContext = () => {
+      return {
+        clearRect() {},
+        fillRect() {},
+        save() {},
+        restore() {},
+        translate() {},
+        rotate() {},
+        globalAlpha: 1,
+      } as any;
+    };
+    (window.HTMLCanvasElement.prototype as any).getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 640,
+      height: 480,
+    });
+
+    const state: BoardState = {
+      size: 20,
+      segmentDefs: [{ segmentId: 's1', name: 'Seg1' }],
+      tokenTypes: [],
+      segments: [],
+      tokens: [],
+    };
+    let added = false;
+    let rendered = false;
+    const api: BoardStateAPI = {
+      newBoard: () => state,
+      addSegment: () => {
+        added = true;
+      },
+      updateSegment: () => {},
+      removeSegment: () => {},
+      addToken: () => {},
+      updateToken: () => {},
+      removeToken: () => {},
+      importMission: () => {},
+      exportMission: () => '',
+      getCellType: () => -1,
+    };
+    const renderer: Renderer = {
+      setSpriteManifest: () => {},
+      loadSpriteManifestFromText: () => {},
+      setAssetResolver: () => {},
+      resize: () => {},
+      render: () => {
+        rendered = true;
+      },
+    };
+
+    const core = new EditorCore(api, state);
+    const container = window.document.getElementById('app')!;
+    const ui = new EditorUI(container, core, renderer);
+
+    const li = container.querySelector('#segment-palette li') as HTMLElement;
+    li.dispatchEvent(new window.Event('click', { bubbles: true }));
+    assert.equal(core.ui.ghost?.kind, 'segment');
+
+    const canvas = container.querySelector('#viewport') as HTMLCanvasElement;
+    canvas.dispatchEvent(
+      new window.MouseEvent('mousemove', { clientX: 40, clientY: 40, bubbles: true }),
+    );
+    assert.deepEqual(core.ui.ghost?.cell, { x: 1, y: 1 });
+
+    canvas.dispatchEvent(new window.MouseEvent('click', { clientX: 40, clientY: 40, bubbles: true }));
+    assert.ok(added);
+    assert.ok(rendered);
+    void ui;
+  });
+});

--- a/Derelict/Editor/tsconfig.json
+++ b/Derelict/Editor/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "./",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "tests"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add pure EditorCore state machine with ghost placement, rotation, and selection
- provide DOM-based EditorUI, ghost overlay rendering, and helpers
- include node:test suites covering core logic, geometry utilities, and rendering overlay

## Testing
- `npm test` *(fails: Cannot find package 'jsdom' imported from dist/tests/ui.smoke.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689a6d937244833393851ff039be7ae4