### PR TITLE
Add project-wide agent instructions

### DIFF
--- a/Derelict/AGENTS.md
+++ b/Derelict/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+- Before modifying code in this repository, review the top-level product requirements in `docs/PRD.txt`.
+- When working within a submodule (`BoardState`, `Editor`, or `Renderer`), read the requirement documents in the submodule's `docs` directory to ensure changes stay aligned with those specifications.
+  - `BoardState/docs/*.md`
+  - `Editor/docs/*.md`
+  - `Renderer/docs/*.md`
+
+These documents define the expected behavior and design for each part of the project.


### PR DESCRIPTION
## Summary
- Add root-level AGENTS.md instructing contributors to review submodule requirement docs before making changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df9c3df408333ae4c00e54ac3504c