### PR TITLE
Use sprite images in token palette

### DIFF
--- a/Derelict/public/main.js
+++ b/Derelict/public/main.js
@@ -69,6 +69,7 @@ async function init() {
   });
 
   const tokenPalette = document.getElementById('token-palette');
+  let selectedTokenBtn = null;
   if (tokenPalette) {
     for (const t of state.tokenTypes) {
       const btn = document.createElement('button');
@@ -82,10 +83,30 @@ async function init() {
       btn.addEventListener('click', () => {
         core.selectToken(t.type);
         ui.setPaletteSelection(null);
+        if (selectedTokenBtn) selectedTokenBtn.classList.remove('selected');
+        btn.classList.add('selected');
+        selectedTokenBtn = btn;
       });
       tokenPalette.appendChild(btn);
     }
   }
+
+  function clearTokenSelection() {
+    if (selectedTokenBtn) {
+      selectedTokenBtn.classList.remove('selected');
+      selectedTokenBtn = null;
+    }
+  }
+
+  const segPalette = document.getElementById('segment-palette');
+  const viewportEl = document.getElementById('viewport');
+  const unselectBtn = document.getElementById('unselect');
+  segPalette?.addEventListener('click', clearTokenSelection);
+  viewportEl?.addEventListener('click', clearTokenSelection);
+  unselectBtn?.addEventListener('click', clearTokenSelection);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') clearTokenSelection();
+  });
 
   function resize() {
     const vp = document.getElementById('viewport');

--- a/Derelict/public/main.js
+++ b/Derelict/public/main.js
@@ -6,14 +6,23 @@ async function init() {
   const app = document.getElementById('app');
   if (!app) return;
 
-  const [segLib, tokLib, spriteManifest] = await Promise.all([
+  const [segLib, tokLib, spriteManifestText] = await Promise.all([
     fetch('assets/segments.txt').then((r) => r.text()),
     fetch('assets/tokens.txt').then((r) => r.text()),
     fetch('assets/sprites.manifest.txt').then((r) => r.text()),
   ]);
 
   const renderer = createRenderer();
-  renderer.loadSpriteManifestFromText(spriteManifest);
+  renderer.loadSpriteManifestFromText(spriteManifestText);
+
+  // Build a simple lookup of sprite file paths for token types
+  const spriteMap = new Map();
+  for (const line of spriteManifestText.split(/\r?\n/)) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length >= 2 && !line.startsWith('#')) {
+      spriteMap.set(parts[0], parts[1]);
+    }
+  }
 
   // Extract segment definitions for editor palettes and ghost rendering
   const segmentDefs = [];
@@ -47,11 +56,29 @@ async function init() {
 
   const { core, ui } = createEditor(app, renderer, BoardState, state);
 
+  const imageCache = new Map();
+  renderer.setAssetResolver((key) => {
+    let img = imageCache.get(key);
+    if (!img) {
+      img = document.createElement('img');
+      img.src = key;
+      img.addEventListener('load', () => ui.render());
+      imageCache.set(key, img);
+    }
+    return img;
+  });
+
   const tokenPalette = document.getElementById('token-palette');
   if (tokenPalette) {
     for (const t of state.tokenTypes) {
       const btn = document.createElement('button');
-      btn.textContent = t.type;
+      const img = document.createElement('img');
+      const file = spriteMap.get(t.type);
+      if (file) img.src = file;
+      const label = document.createElement('div');
+      label.textContent = t.type;
+      btn.appendChild(img);
+      btn.appendChild(label);
       btn.addEventListener('click', () => {
         core.selectToken(t.type);
         ui.setPaletteSelection(null);

--- a/Derelict/public/styles.css
+++ b/Derelict/public/styles.css
@@ -66,6 +66,11 @@ html, body {
   gap: 4px;
 }
 
+#token-palette button.selected {
+  background: #444;
+  color: #fff;
+}
+
 #token-palette button img {
   width: 48px;
   height: 48px;

--- a/Derelict/public/styles.css
+++ b/Derelict/public/styles.css
@@ -60,4 +60,14 @@ html, body {
 }
 #token-palette button {
   flex: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+#token-palette button img {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
 }

--- a/Derelict/tests/main.test.js
+++ b/Derelict/tests/main.test.js
@@ -51,4 +51,12 @@ test('bootstrap initializes without errors', async () => {
 
   const tokens = document.querySelectorAll('#token-palette button');
   assert.ok(tokens.length > 0, 'token buttons populated');
+
+  const firstToken = tokens[0];
+  firstToken.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+  assert.ok(firstToken.classList.contains('selected'), 'token button highlights on select');
+
+  const seg = document.querySelector('#segment-palette li');
+  seg?.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+  assert.ok(!firstToken.classList.contains('selected'), 'token highlight clears on segment select');
 });


### PR DESCRIPTION
## Summary
- Load image assets referenced by the sprite manifest
- Show token sprites with labels in the palette
- Style token buttons to stack sprite over text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e441eb8d88333b9c5c0a95195c588