### PR TITLE
Initialize board with walls and render terrain

### DIFF
--- a/Derelict/BoardState/src/api/public.ts
+++ b/Derelict/BoardState/src/api/public.ts
@@ -8,7 +8,9 @@ import { createState, placeSegment, removeSegmentAtCoordInternal, placeToken, re
 export function newBoard(size: number, segmentLibrary: string, tokenLibrary: string): BoardState {
   const segDefs = parseSegmentLibrary(segmentLibrary);
   const tokDefs = parseTokenLibrary(tokenLibrary);
-  return createState(size, segDefs, tokDefs);
+  const state = createState(size, segDefs, tokDefs);
+  (state as any).getCellType = (coord: Coord) => cellTypeAt(state as any, coord);
+  return state;
 }
 
 export function loadBoard(size: number, segmentLibrary: string, tokenLibrary: string, missionFile: string): BoardState {
@@ -16,6 +18,7 @@ export function loadBoard(size: number, segmentLibrary: string, tokenLibrary: st
   const tokDefs = parseTokenLibrary(tokenLibrary);
   const mission = parseMission(missionFile);
   const state = createState(mission.size || size, segDefs, tokDefs);
+  (state as any).getCellType = (coord: Coord) => cellTypeAt(state as any, coord);
   for (const s of mission.segments) {
     placeSegment(state, s);
   }

--- a/Derelict/BoardState/src/core/types.ts
+++ b/Derelict/BoardState/src/core/types.ts
@@ -30,6 +30,7 @@ export interface BoardState {
   size: number; // board is size x size (square)
   segments: SegmentInstance[];
   tokens: TokenInstance[];
+  getCellType?(coord: Coord): CellType | -1;
 }
 
 export interface TokenDef {

--- a/Derelict/BoardState/tests/init.test.js
+++ b/Derelict/BoardState/tests/init.test.js
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { newBoard, getCellType } from '../dist/api/public.js';
+
+const fixture = (p) => fs.readFileSync(path.join('fixtures', p), 'utf8');
+
+describe('initialization', () => {
+  const segLib = fixture('lib_segments.txt');
+  const tokLib = fixture('lib_tokens.txt');
+  it('new board has 40x40 walls', () => {
+    const board = newBoard(40, segLib, tokLib);
+    assert.equal(board.size, 40);
+    assert.equal(typeof board.getCellType, 'function');
+    assert.strictEqual(getCellType(board, { x: 0, y: 0 }), 0);
+    assert.strictEqual(getCellType(board, { x: 39, y: 39 }), 0);
+  });
+});

--- a/Derelict/BoardState/tests/mission.test.js
+++ b/Derelict/BoardState/tests/mission.test.js
@@ -21,6 +21,8 @@ describe('mission import/export', () => {
     const board = loadBoard(40, segLib, tokLib, missionText);
     const text = saveBoard(board, 'Test');
     const board2 = loadBoard(40, segLib, tokLib, text);
+    delete board.getCellType;
+    delete board2.getCellType;
     assert.deepStrictEqual(board2, board);
   });
 

--- a/Derelict/BoardState/tests/queries.test.js
+++ b/Derelict/BoardState/tests/queries.test.js
@@ -12,8 +12,8 @@ describe('queries', () => {
   const missionText = fixture('mission.txt');
   const board = loadBoard(40, segLib, tokLib, missionText);
 
-  it('getCellType returns -1 for uncovered and correct for covered', () => {
-    assert.strictEqual(getCellType(board, { x: 0, y: 0 }), -1);
+  it('getCellType returns base cell type and correct for covered', () => {
+    assert.strictEqual(getCellType(board, { x: 0, y: 0 }), 0);
     assert.strictEqual(getCellType(board, { x: 12, y: 12 }), 1);
   });
 

--- a/Derelict/BoardState/tests/serialization.test.js
+++ b/Derelict/BoardState/tests/serialization.test.js
@@ -22,6 +22,8 @@ describe('serialization', () => {
     addToken(board, { instanceId: 'T1', type: 'door', rot: 0, cells: [{ x: 2, y: 2 }], attrs: { a: 1 } });
     const json = serializeSave(board);
     const board2 = deserializeSave(json, segDefs, tokDefs);
+    delete board.getCellType;
+    delete board2.getCellType;
     assert.deepStrictEqual(board2, board);
   });
 

--- a/Derelict/Editor/src/editor/EditorUI.ts
+++ b/Derelict/Editor/src/editor/EditorUI.ts
@@ -92,7 +92,15 @@ export class EditorUI {
 
   render() {
     const ctx = this.viewport.getContext('2d');
-    if (ctx) this.renderer.render(ctx, this.core.getState(), { x: 0, y: 0 });
+    if (ctx) {
+      const state = this.core.getState();
+      const cellSize = this.viewport.width / state.size;
+      this.renderer.render(ctx, state, {
+        origin: { x: 0, y: 0 },
+        scale: 1,
+        cellSize,
+      });
+    }
     this.drawGhost();
   }
 }

--- a/Derelict/Renderer/tests/renderer.test.ts
+++ b/Derelict/Renderer/tests/renderer.test.ts
@@ -97,6 +97,29 @@ test('renderer applies token offsets and rotation', () => {
   );
 });
 
+test('renderer draws terrain and tokens layered', () => {
+  const renderer = createRenderer();
+  const manifest = loadSpriteManifestFromText(
+    `0 wall.png 0 0 0 0 0 0 0\nfoo foo.png 0 0 0 0 1 0 0`
+  );
+  renderer.setSpriteManifest(manifest);
+  renderer.setAssetResolver((key) => ({ width: 1, height: 1, src: key } as any));
+  renderer.resize(64, 64);
+  const state: BoardState = {
+    size: 2,
+    segments: [],
+    tokens: [{ tokenId: 't', type: 'foo', rot: 0, cells: [{ x: 0, y: 0 }] }],
+    getCellType: () => 0,
+  } as any;
+  const { ctx, calls } = makeCtx();
+  renderer.render(ctx as any, state, viewport);
+  // 4 cells + 1 token
+  assert.equal(calls.drawImage.length, 5);
+  // last draw call should be token sprite
+  const last = calls.drawImage[calls.drawImage.length - 1][0];
+  assert.equal(last.src, 'foo.png');
+});
+
 const hasOffscreen = typeof OffscreenCanvas !== 'undefined';
 const offscreenTest = hasOffscreen ? test : test.skip;
 offscreenTest('renderer smoke test with OffscreenCanvas', () => {


### PR DESCRIPTION
## Summary
- Seed BoardState with a 40×40 grid of wall cells and expose `getCellType`
- Supply Renderer with proper viewport data and add tests for terrain/token layering
- Update BoardState tests for default walls and mission/serialization equality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e5261db6883339f0014a3a8e0968e