### PR TITLE
feat(renderer): draw segment outlines

### DIFF
--- a/Derelict/Renderer/docs/ChatGPT5-SRD.md
+++ b/Derelict/Renderer/docs/ChatGPT5-SRD.md
@@ -9,7 +9,7 @@ Provide a **pure rendering library** that draws a `BoardState` onto a `Canvas2D`
 * Consume: **BoardState** (read-only) and a **Sprite Manifest**.
 * Output: pixels on a provided canvas context.
 * Support camera/viewport transforms (pan/zoom) supplied by the caller.
-* Optional overlays for debug (segment bounds) provided via flags.
+* Segment bounds are always drawn as 2px gray outlines after terrain and before tokens.
 
 ## 3. External Interfaces
 
@@ -27,7 +27,7 @@ Provide a **pure rendering library** that draws a `BoardState` onto a `Canvas2D`
 
 * **R-001** Render visible **cell terrain** based on `getCellType(x,y)` across the viewport’s bounds.
 * **R-002** Render **tokens** by iterating `getTokens()`; for each `token.cells` draw the token sprite with rotation `token.rot` (0/90/180/270) around a pixel offset defined by the manifest.
-* **R-003** Optional **segment bounds overlay**: draw axis-aligned rectangles for each `SegmentInstance` when `options.showSegmentBounds` is true.
+* **R-003** Draw **segment bounds overlay**: stroke axis-aligned rectangles for each `SegmentInstance` using 2px gray lines.
 * **R-004** **HiDPI**: respect `devicePixelRatio` (provided by caller) to avoid blur.
 * **R-005** **Culling**: skip drawing cells/tokens outside the viewport.
 * **R-006** **Layering**: draw terrain, then tokens in ascending **layer** order from the manifest, then stable insertion order.
@@ -89,7 +89,6 @@ export interface Viewport {
 export interface RenderOptions {
   clear?: boolean;                  // clear before draw (default true)
   background?: string | null;       // CSS color or null for transparent
-  showSegmentBounds?: boolean;
 }
 
 export type AssetResolver = (key: string) => HTMLImageElement | ImageBitmap | undefined;
@@ -137,7 +136,7 @@ export function createRenderer(): Renderer;
 1. With a given BoardState and manifest, repeated `render` calls are pixel-identical.
 2. Viewport pan/zoom updates translate/scale output correctly with HiDPI crispness.
 3. Culling ensures no draw calls for fully off-screen cells/tokens.
-4. Segment bounds overlay appears when enabled and aligns with terrain.
+4. Segment bounds overlay aligns with terrain.
 5. Fallback visuals appear for missing sprites without errors.
 
 ## 12. Notes on JSON vs Text Manifests

--- a/Derelict/Renderer/docs/codex-prompt.md
+++ b/Derelict/Renderer/docs/codex-prompt.md
@@ -41,7 +41,6 @@ export interface Viewport {
 export interface RenderOptions {
   clear?: boolean;
   background?: string | null;
-  showSegmentBounds?: boolean;
 }
 
 export type AssetResolver = (key: string) =>
@@ -161,7 +160,7 @@ Rendering rules
 
     Culling: skip cells/tokens whose cell rect is fully outside the canvas (use isCellVisible).
 
-    segment bounds overlay: when options.showSegmentBounds, stroke axis-aligned rectangles for each SegmentInstance based on its width/height after rotation (hint: ask caller for a helper OR compute from segment defs if available; for MVP you can omit exact bounds and simply draw a rect per occupied cell to form the outline).
+    segment bounds overlay: stroke axis-aligned rectangles for each SegmentInstance based on its width/height after rotation using 2px gray lines.
 
 API design notes
 

--- a/Derelict/Renderer/src/renderer.ts
+++ b/Derelict/Renderer/src/renderer.ts
@@ -209,31 +209,29 @@ export function createRenderer(): Renderer {
     terrainCalls.sort((a, b) => a.layer - b.layer);
     for (const d of terrainCalls) d.fn();
 
-    if (options?.showSegmentBounds) {
-      ctx.save();
-      ctx.lineWidth = 2;
-      ctx.strokeStyle = 'gray';
-      for (const seg of state.segments) {
-        const segId = (seg as any).segmentId ?? (seg as any).type;
-        const def = state.segmentDefs?.find((s) => s.segmentId === segId);
-        const width = def?.grid?.[0]?.length ?? def?.width ?? 1;
-        const height = def?.grid?.length ?? def?.height ?? 1;
-        let w = width;
-        let h = height;
-        if (seg.rot === 90 || seg.rot === 270) {
-          [w, h] = [h, w];
-        }
-        const rect = boardToScreen(seg.origin, viewport);
-        const px = rect.x;
-        const py = rect.y;
-        const pw = rect.width * w;
-        const ph = rect.height * h;
-        if (px + pw <= 0 || py + ph <= 0 || px >= canvasPx.w || py >= canvasPx.h)
-          continue;
-        ctx.strokeRect(px, py, pw, ph);
+    ctx.save();
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = 'gray';
+    for (const seg of state.segments) {
+      const segId = (seg as any).segmentId ?? (seg as any).type;
+      const def = state.segmentDefs?.find((s) => s.segmentId === segId);
+      const width = def?.grid?.[0]?.length ?? def?.width ?? 1;
+      const height = def?.grid?.length ?? def?.height ?? 1;
+      let w = width;
+      let h = height;
+      if (seg.rot === 90 || seg.rot === 270) {
+        [w, h] = [h, w];
       }
-      ctx.restore();
+      const rect = boardToScreen(seg.origin, viewport);
+      const px = rect.x;
+      const py = rect.y;
+      const pw = rect.width * w;
+      const ph = rect.height * h;
+      if (px + pw <= 0 || py + ph <= 0 || px >= canvasPx.w || py >= canvasPx.h)
+        continue;
+      ctx.strokeRect(px, py, pw, ph);
     }
+    ctx.restore();
 
     tokenCalls.sort((a, b) => a.layer - b.layer);
     for (const d of tokenCalls) d.fn();

--- a/Derelict/Renderer/src/types.ts
+++ b/Derelict/Renderer/src/types.ts
@@ -10,7 +10,6 @@ export interface Viewport {
 export interface RenderOptions {
   clear?: boolean;
   background?: string | null;
-  showSegmentBounds?: boolean;
 }
 
 export interface BoardState {

--- a/Derelict/Renderer/tests/renderer.test.ts
+++ b/Derelict/Renderer/tests/renderer.test.ts
@@ -188,7 +188,7 @@ test('renderer draws segment bounds before tokens', () => {
     ],
   } as any;
   const { ctx, calls } = makeCtx();
-  renderer.render(ctx as any, state, viewport, { showSegmentBounds: true });
+  renderer.render(ctx as any, state, viewport);
   assert.equal(calls.strokeRect.length, 1);
   assert.ok(calls.lineWidth.includes(2));
   assert.ok(calls.strokeStyle.includes('gray'));
@@ -210,7 +210,7 @@ test('renderer draws bounds for segments without defs', () => {
     tokens: [],
   } as any;
   const { ctx, calls } = makeCtx();
-  renderer.render(ctx as any, state, viewport, { showSegmentBounds: true });
+  renderer.render(ctx as any, state, viewport);
   assert.equal(calls.strokeRect.length, 1);
 });
 


### PR DESCRIPTION
## Summary
- draw gray 2px outlines for segment instances before rendering tokens
- test segment outline rendering order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a20255376883338745dc88abe145ef