### PR TITLE
feat(editor): add save mission dialog

### DIFF
--- a/Derelict/BoardState/src/io/mission.serialize.ts
+++ b/Derelict/BoardState/src/io/mission.serialize.ts
@@ -14,7 +14,9 @@ export function serializeMission(state: BoardState, missionName = 'Untitled'): s
   }
   lines.push('');
   lines.push('tokens:');
-  const toks = [...state.tokens].sort((a, b) => a.instanceId.localeCompare(b.instanceId));
+  const toks = state.tokens
+    .filter((t) => t.instanceId)
+    .sort((a, b) => a.instanceId.localeCompare(b.instanceId));
   for (const t of toks) {
     const pos = t.cells[0];
     const attr = t.attrs ? ` attrs=${JSON.stringify(t.attrs)}` : '';

--- a/Derelict/BoardState/tests/mission.test.js
+++ b/Derelict/BoardState/tests/mission.test.js
@@ -36,5 +36,12 @@ describe('mission import/export', () => {
     const text2 = exportBoardText(board, 'Test');
     assert.strictEqual(text1, text2);
   });
+
+  it('export skips tokens missing instanceId', () => {
+    const board = newBoard(40, segLib, tokLib);
+    importBoardText(board, missionText);
+    board.tokens.push({ type: 'door', rot: 0, cells: [{ x: 0, y: 0 }] });
+    assert.doesNotThrow(() => exportBoardText(board, 'Test'));
+  });
 });
 

--- a/Derelict/Editor/src/adapters/BoardStateAdapter.ts
+++ b/Derelict/Editor/src/adapters/BoardStateAdapter.ts
@@ -24,7 +24,7 @@ export class BoardStateAdapter {
     this.api.removeSegment(this.state, id);
   }
   addToken(tok: {
-    tokenId: string;
+    instanceId: string;
     type: string;
     rot: 0 | 90 | 180 | 270;
     cells: { x: number; y: number }[];

--- a/Derelict/Editor/src/editor/EditorCore.ts
+++ b/Derelict/Editor/src/editor/EditorCore.ts
@@ -82,7 +82,7 @@ export class EditorCore {
       } else if (g.kind === 'token') {
         const id = `tok-${Date.now()}`;
         this.api.addToken(this.state, {
-          tokenId: id,
+          instanceId: id,
           type: g.id,
           rot: g.rot,
           cells: [g.cell],

--- a/Derelict/Editor/src/editor/EditorCore.ts
+++ b/Derelict/Editor/src/editor/EditorCore.ts
@@ -7,8 +7,12 @@ function nextRot(rot: 0 | 90 | 180 | 270, dir: 1 | -1): 0 | 90 | 180 | 270 {
 
 export class EditorCore {
   private _ui: EditorState = { selected: null, ghost: null };
+  private missionName: string;
 
-  constructor(private api: BoardStateAPI, private state: BoardState) {}
+  constructor(private api: BoardStateAPI, private state: BoardState) {
+    this.missionName = state.missionName || 'Unnamed Mission';
+    this.state.missionName = this.missionName;
+  }
 
   get ui(): Readonly<EditorState> {
     return JSON.parse(JSON.stringify(this._ui));
@@ -16,6 +20,15 @@ export class EditorCore {
 
   getState(): BoardState {
     return this.state;
+  }
+
+  getMissionName(): string {
+    return this.missionName;
+  }
+
+  private setMissionName(name: string) {
+    this.missionName = name;
+    this.state.missionName = name;
   }
 
   selectSegment(segmentId: string): void {
@@ -92,15 +105,19 @@ export class EditorCore {
 
   newMission(name: string, size: number, segLibText: string, tokenLibText: string): void {
     this.state = this.api.newBoard(size, segLibText, tokenLibText);
+    this.setMissionName(name || 'Unnamed Mission');
     this.clearSelection();
   }
 
   loadMission(text: string): void {
+    const m = text.match(/^mission:\s*(.+)$/m);
+    this.setMissionName(m ? m[1].trim() : 'Unnamed Mission');
     this.api.importBoardText(this.state, text);
     this.clearSelection();
   }
 
-  saveMission(name = 'Untitled'): string {
-    return this.api.exportBoardText(this.state, name);
+  saveMission(name = this.missionName): string {
+    this.setMissionName(name);
+    return this.api.exportBoardText(this.state, this.missionName);
   }
 }

--- a/Derelict/Editor/src/editor/EditorUI.ts
+++ b/Derelict/Editor/src/editor/EditorUI.ts
@@ -111,7 +111,7 @@ export class EditorUI {
 
     const addItem = (label: string, loader: () => void | Promise<void>) => {
       const li = createEl('li');
-      li.textContent = label.replace(/\.txt$/i, '');
+      li.textContent = label.replace(/\.mission\.txt$/i, '').replace(/\.txt$/i, '');
       li.addEventListener('click', async () => {
         await loader();
         this.setPaletteSelection(null);
@@ -167,7 +167,8 @@ export class EditorUI {
   }
 
   private async performSave(name: string): Promise<boolean> {
-    const fileName = name.replace(/\s+/g, '-') + '.txt';
+    const base = name.replace(/\s+/g, '-');
+    const fileName = base.endsWith('.mission.txt') ? base : base + '.mission.txt';
     const key = 'mission:' + fileName;
     if (typeof localStorage !== 'undefined' && localStorage.getItem(key)) {
       const proceed = await new Promise<boolean>((resolve) => {

--- a/Derelict/Editor/src/editor/Shortcuts.ts
+++ b/Derelict/Editor/src/editor/Shortcuts.ts
@@ -7,6 +7,16 @@ export interface ShortcutHandlers {
 
 export function registerShortcuts(target: HTMLElement | Document, h: ShortcutHandlers) {
   (target as any).addEventListener('keydown', (ev: KeyboardEvent) => {
+    const targetEl = ev.target as HTMLElement | null;
+    const tag = targetEl?.tagName;
+    const modalOpen = document.querySelector('.modal-overlay');
+    const editable =
+      targetEl?.isContentEditable ||
+      tag === 'INPUT' ||
+      tag === 'TEXTAREA' ||
+      tag === 'SELECT';
+    if (modalOpen || editable) return;
+
     if (ev.key === 'r' || ev.key === 'R') {
       h.rotate?.(ev.shiftKey ? -1 : 1);
       ev.preventDefault();

--- a/Derelict/Editor/src/types.ts
+++ b/Derelict/Editor/src/types.ts
@@ -49,7 +49,7 @@ export interface BoardStateAPI {
   addToken(
     state: BoardState,
     tok: {
-      tokenId: string;
+      instanceId: string;
       type: string;
       rot: 0 | 90 | 180 | 270;
       cells: { x: number; y: number }[];

--- a/Derelict/Editor/src/types.ts
+++ b/Derelict/Editor/src/types.ts
@@ -21,6 +21,7 @@ export interface Renderer {
 
 export interface BoardState {
   size: number;
+  missionName: string;
   segmentDefs: {
     segmentId: string;
     name?: string;

--- a/Derelict/Editor/src/util/files.ts
+++ b/Derelict/Editor/src/util/files.ts
@@ -8,11 +8,13 @@ export function readFileAsText(f: File): Promise<string> {
 }
 
 export function downloadText(name: string, text: string) {
-  const blob = new Blob([text], { type: 'text/plain' });
+  const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = name;
+  a.download = name.endsWith('.mission.txt') ? name : name + '.mission.txt';
+  document.body.appendChild(a);
   a.click();
+  a.remove();
   URL.revokeObjectURL(url);
 }

--- a/Derelict/Editor/tests/core.test.ts
+++ b/Derelict/Editor/tests/core.test.ts
@@ -6,6 +6,7 @@ import type { BoardState, BoardStateAPI } from '../src/types.js';
 function makeState(): BoardState {
   return {
     size: 10,
+    missionName: 'Unnamed Mission',
     segmentDefs: [{ segmentId: 'segA', name: 'SegA' }],
     tokenTypes: [{ type: 'tokA' }],
     segments: [],

--- a/Derelict/Editor/tests/shortcuts.test.ts
+++ b/Derelict/Editor/tests/shortcuts.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { registerShortcuts } from '../src/editor/Shortcuts.js';
+import { showModal, createEl } from '../src/util/dom.js';
+
+describe('registerShortcuts', () => {
+  it('ignores keys when typing in input or modal open', () => {
+    const dom = new JSDOM(`<!doctype html><html><body><input id="name"></body></html>`, { pretendToBeVisual: true });
+    const { window } = dom;
+    (globalThis as any).window = window;
+    (globalThis as any).document = window.document;
+
+    let rotated = false;
+    registerShortcuts(window.document, {
+      rotate: () => {
+        rotated = true;
+      },
+    });
+
+    const input = window.document.getElementById('name') as HTMLInputElement;
+    input.focus();
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'r', bubbles: true }));
+    assert.equal(rotated, false);
+
+    rotated = false;
+    const body = createEl('div');
+    showModal('Test', body, [{ label: 'OK', onClick: () => {} }]);
+    window.document.body.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'r', bubbles: true }));
+    assert.equal(rotated, false);
+  });
+});

--- a/Derelict/Editor/tests/ui.smoke.test.ts
+++ b/Derelict/Editor/tests/ui.smoke.test.ts
@@ -33,6 +33,7 @@ describe('EditorUI smoke test', () => {
 
     const state: BoardState = {
       size: 20,
+      missionName: 'Unnamed Mission',
       segmentDefs: [{ segmentId: 's1', name: 'Seg1' }],
       tokenTypes: [],
       segments: [],
@@ -119,6 +120,7 @@ describe('EditorUI smoke test', () => {
     });
     const state: BoardState = {
       size: 40,
+      missionName: 'Unnamed Mission',
       segmentDefs: [],
       tokenTypes: [],
       segments: [],

--- a/Derelict/public/main.js
+++ b/Derelict/public/main.js
@@ -36,6 +36,7 @@ async function init() {
   // Augment state for Editor expectations
   state.segmentDefs = segmentDefs;
   state.tokenTypes = tokenTypes.map((t) => ({ type: t }));
+  state.missionName = 'Unnamed Mission';
 
   const { core, ui } = createEditor(app, renderer, BoardState, state);
 


### PR DESCRIPTION
## Summary
- track mission names in board state
- add save mission modal with overwrite confirmation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a203157f3883339a51b7ed084072fe