### PR TITLE
Enable token selection and rotation from selection panel

### DIFF
--- a/Derelict/Editor/src/editor/EditorUI.ts
+++ b/Derelict/Editor/src/editor/EditorUI.ts
@@ -335,10 +335,14 @@ export class EditorUI {
     });
     li.textContent += ' ';
     li.appendChild(del);
-    li.addEventListener('click', () => {
-      this.core.selectExisting(kind, id);
-      this.refreshSelectionHighlight();
-    });
+    if (kind === 'token') {
+      li.addEventListener('click', () => {
+        this.core.selectExisting('token', id);
+        this.refreshSelectionHighlight();
+      });
+    } else {
+      li.classList.add('no-select');
+    }
     return li;
   }
 

--- a/Derelict/Editor/src/editor/styles.css
+++ b/Derelict/Editor/src/editor/styles.css
@@ -5,6 +5,7 @@
 #selection-bar .label { font-weight:bold; }
 #selection-list { list-style:none; margin:0; padding:0; }
 #selection-list li { display:flex; justify-content:space-between; cursor:pointer; }
+#selection-list li.no-select { cursor:default; }
 #selection-list li.selected { background:#444; color:#fff; }
 #selection-list .del { color:red; margin-left:4px; cursor:pointer; }
 #segment-palette li.selected { background:#444; color:#fff; }

--- a/Derelict/Editor/tests/core.test.ts
+++ b/Derelict/Editor/tests/core.test.ts
@@ -202,4 +202,29 @@ describe('EditorCore basics', () => {
     core.rotate(1);
     assert.equal(state.segments[0].rot, 90);
   });
+
+  it('rotate selected token', () => {
+    const state = makeState();
+    state.tokens.push({
+      instanceId: 't1',
+      type: 'tokA',
+      rot: 0,
+      cells: [{ x: 0, y: 0 }],
+    });
+    const api: BoardStateAPI = {
+      newBoard: () => state,
+      addSegment: () => {},
+      removeSegment: () => {},
+      addToken: () => {},
+      removeToken: () => {},
+      importBoardText: () => {},
+      exportBoardText: () => '',
+      getCellType: () => -1,
+      findById: (_s, id) => state.tokens.find((t) => t.instanceId === id),
+    };
+    const core = new EditorCore(api, state);
+    core.selectExisting('token', 't1');
+    core.rotate(1);
+    assert.equal(state.tokens[0].rot, 90);
+  });
 });


### PR DESCRIPTION
## Summary
- Allow selecting tokens from the selection panel while preventing segment selection
- Update styles so non-selectable entries show default cursor
- Support rotating already placed tokens and add tests for token rotation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6248eac288333b338aba27b73b1f2