### PR TITLE
Fix token selection panel update

### DIFF
--- a/Derelict/public/main.js
+++ b/Derelict/public/main.js
@@ -67,6 +67,8 @@ async function init() {
       btn.addEventListener('click', () => {
         core.selectToken(t.type);
         ui.setPaletteSelection(null);
+        ui.drawGhost();
+        ui.updateSelectionBar();
         if (selectedTokenBtn) selectedTokenBtn.classList.remove('selected');
         btn.classList.add('selected');
         selectedTokenBtn = btn;

--- a/Derelict/tests/main.test.js
+++ b/Derelict/tests/main.test.js
@@ -57,6 +57,11 @@ test('bootstrap initializes without errors', async () => {
   firstToken.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
   assert.ok(firstToken.classList.contains('selected'), 'token button highlights on select');
 
+  const selItems = document.querySelectorAll('#selection-list li');
+  assert.equal(selItems.length, 1, 'selection list shows token');
+  const tokenLabel = firstToken.querySelector('div')?.textContent?.trim();
+  assert.ok(selItems[0].textContent?.includes(tokenLabel || ''));
+
   const seg = document.querySelector('#segment-palette li');
   seg?.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
   assert.ok(!firstToken.classList.contains('selected'), 'token highlight clears on segment select');


### PR DESCRIPTION
## Summary
- Update token palette click handler to refresh selection panel and ghost preview
- Add regression test ensuring token selection populates selection list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad7a9643a883339d35f8f599e607be