### PR TITLE
Unify player choice API and expand rules loop

### DIFF
--- a/Derelict/Game/src/index.ts
+++ b/Derelict/Game/src/index.ts
@@ -1,19 +1,36 @@
 import type { BoardState, Coord } from 'derelict-boardstate';
 import type { Rules } from 'derelict-rules';
-import type { Player, GameApi } from 'derelict-players';
+import type { Player, GameApi, Choice } from 'derelict-players';
 
 export interface RendererLike {
   render(state: BoardState): void;
 }
 
+interface SpriteInfo {
+  file: string;
+  xoff: number;
+  yoff: number;
+}
+
+export interface ChooseUI {
+  container: HTMLElement;
+  cellToRect: (
+    coord: Coord,
+  ) => { x: number; y: number; width: number; height: number };
+  sprites: Record<string, SpriteInfo>;
+}
+
 // Core game orchestrator providing the GameApi for human players
 export class Game implements GameApi {
+  private preselect: Coord | null = null;
+
   constructor(
     private board: BoardState,
     private renderer: RendererLike,
     private rules: Rules,
     private player1: Player,
-    private player2: Player
+    private player2: Player,
+    private ui?: ChooseUI,
   ) {}
 
   async start(): Promise<void> {
@@ -22,20 +39,97 @@ export class Game implements GameApi {
     await this.rules.runGame(this.player1, this.player2);
   }
 
-  async chooseCell(allowed: Coord[]): Promise<Coord> {
-    // Placeholder implementation: pick the first allowed coordinate
-    return allowed[0];
+  async choose(options: Choice[]): Promise<Choice> {
+    if (this.preselect) {
+      const found = options.find(
+        (o) => o.type === 'marine' && o.coord && sameCoord(o.coord, this.preselect!),
+      );
+      if (found) {
+        this.preselect = null;
+        return found;
+      }
+      this.preselect = null;
+    }
+    if (!this.ui) return options[0];
+
+    return new Promise<Choice>((resolve) => {
+      const elements: HTMLElement[] = [];
+      const cleanup = () => {
+        for (const el of elements) el.remove();
+      };
+
+      const { container, cellToRect, sprites } = this.ui!;
+      const key = (c: Coord) => `${c.x},${c.y}`;
+
+      const marineMap = new Map<string, Choice>();
+      for (const opt of options) {
+        if (opt.type === 'marine' && opt.coord) marineMap.set(key(opt.coord), opt);
+      }
+
+      const selectOther = options.find(
+        (o) => o.type === 'action' && o.action === 'selectOther',
+      );
+
+      for (const opt of options) {
+        if (opt.type === 'action' && opt.coord && opt.sprite) {
+          const rect = cellToRect(opt.coord);
+          const info = sprites[opt.sprite] || { file: opt.sprite, xoff: 0, yoff: 0 };
+          const img = document.createElement('img');
+          img.src = info.file;
+          img.style.position = 'absolute';
+          const cx = rect.x + rect.width / 2;
+          const cy = rect.y + rect.height / 2;
+          const rad = ((opt.rot || 0) * Math.PI) / 180;
+          const ox = info.xoff * Math.cos(rad) - info.yoff * Math.sin(rad);
+          const oy = info.xoff * Math.sin(rad) + info.yoff * Math.cos(rad);
+          img.style.left = `${cx + ox}px`;
+          img.style.top = `${cy + oy}px`;
+          img.style.transform = `translate(-50%, -50%) rotate(${opt.rot || 0}deg)`;
+          img.style.cursor = 'pointer';
+          img.addEventListener('click', (e) => {
+            e.stopPropagation();
+            cleanup();
+            resolve(opt);
+          });
+          container.appendChild(img);
+          elements.push(img);
+        }
+      }
+
+      const marines = this.board.tokens.filter((t) => t.type === 'marine');
+      for (const t of marines) {
+        const coord = t.cells[0];
+        const rect = cellToRect(coord);
+        const div = document.createElement('div');
+        div.style.position = 'absolute';
+        div.style.left = `${rect.x}px`;
+        div.style.top = `${rect.y}px`;
+        div.style.width = `${rect.width}px`;
+        div.style.height = `${rect.height}px`;
+        div.style.cursor = 'pointer';
+        div.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const m = marineMap.get(key(coord));
+          if (m) {
+            cleanup();
+            resolve(m);
+          } else if (selectOther) {
+            this.preselect = coord;
+            cleanup();
+            resolve(selectOther);
+          }
+        });
+        container.appendChild(div);
+        elements.push(div);
+      }
+    });
   }
 
   async messageBox(_message: string): Promise<boolean> {
     return true;
   }
+}
 
-  highlightCells(_coords: Coord[]): void {
-    // no-op for now
-  }
-
-  clearHighlights(): void {
-    // no-op for now
-  }
+function sameCoord(a: Coord, b: Coord): boolean {
+  return a.x === b.x && a.y === b.y;
 }

--- a/Derelict/Game/tests/game.test.js
+++ b/Derelict/Game/tests/game.test.js
@@ -21,8 +21,7 @@ test('start validates and runs rules', async () => {
     },
   };
   const player = {
-    chooseMarine: async () => ({ x: 0, y: 0 }),
-    chooseAction: async () => 'move',
+    choose: async () => ({ type: 'marine', coord: { x: 0, y: 0 } }),
   };
   const game = new Game(board, renderer, rules, player, player);
   await game.start();

--- a/Derelict/Game/types/external.d.ts
+++ b/Derelict/Game/types/external.d.ts
@@ -11,20 +11,25 @@ declare module 'derelict-boardstate' {
     size: number;
     segments: any[];
     tokens: TokenInstance[];
+    getCellType?(coord: Coord): number;
   }
 }
 
 declare module 'derelict-players' {
   import type { Coord } from 'derelict-boardstate';
+  export interface Choice {
+    type: 'marine' | 'action';
+    coord?: Coord;
+    action?: 'move' | 'turnLeft' | 'turnRight' | 'selectOther';
+    sprite?: string;
+    rot?: number;
+  }
   export interface GameApi {
-    chooseCell(allowed: Coord[]): Promise<Coord>;
+    choose(options: Choice[]): Promise<Choice>;
     messageBox(message: string): Promise<boolean>;
-    highlightCells(coords: Coord[]): void;
-    clearHighlights(): void;
   }
   export interface Player {
-    chooseMarine(options: Coord[]): Promise<Coord>;
-    chooseAction(options: string[]): Promise<string>;
+    choose(options: Choice[]): Promise<Choice>;
   }
 }
 

--- a/Derelict/Players/src/index.ts
+++ b/Derelict/Players/src/index.ts
@@ -1,41 +1,37 @@
 import { Coord } from 'derelict-boardstate';
 
+// A generic choice presented to a player.
+export interface Choice {
+  type: 'marine' | 'action';
+  coord?: Coord;
+  action?: 'move' | 'turnLeft' | 'turnRight' | 'selectOther';
+  sprite?: string;
+  rot?: number;
+}
+
 // Game API that players can call to interact with the UI
 export interface GameApi {
-  chooseCell(allowed: Coord[]): Promise<Coord>;
+  choose(options: Choice[]): Promise<Choice>;
   messageBox(message: string): Promise<boolean>;
-  highlightCells(coords: Coord[]): void;
-  clearHighlights(): void;
 }
 
 // Basic player interface used by the rules engine
 export interface Player {
-  chooseMarine(options: Coord[]): Promise<Coord>;
-  chooseAction(options: string[]): Promise<string>;
+  choose(options: Choice[]): Promise<Choice>;
 }
 
 // Human controlled player delegating to the Game UI
 export class HumanPlayer implements Player {
   constructor(private game: GameApi) {}
 
-  chooseMarine(options: Coord[]): Promise<Coord> {
-    return this.game.chooseCell(options);
-  }
-
-  async chooseAction(options: string[]): Promise<string> {
-    // Placeholder: always pick the first option
-    return options[0];
+  choose(options: Choice[]): Promise<Choice> {
+    return this.game.choose(options);
   }
 }
 
 // Simple computer player making random choices
 export class RandomAI implements Player {
-  async chooseMarine(options: Coord[]): Promise<Coord> {
-    const idx = Math.floor(Math.random() * options.length);
-    return options[idx];
-  }
-
-  async chooseAction(options: string[]): Promise<string> {
+  async choose(options: Choice[]): Promise<Choice> {
     const idx = Math.floor(Math.random() * options.length);
     return options[idx];
   }

--- a/Derelict/Players/tests/players.test.js
+++ b/Derelict/Players/tests/players.test.js
@@ -2,28 +2,26 @@ import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { HumanPlayer, RandomAI } from '../dist/src/index.js';
 
-test('HumanPlayer delegates to GameApi.chooseCell', async () => {
-  const options = [{ x: 0, y: 0 }];
+test('HumanPlayer delegates to GameApi.choose', async () => {
+  const options = [{ type: 'marine', coord: { x: 0, y: 0 } }];
   let called = false;
   const game = {
-    chooseCell: async (allowed) => {
+    choose: async (allowed) => {
       called = true;
       assert.deepEqual(allowed, options);
       return options[0];
     },
     messageBox: async () => true,
-    highlightCells: () => {},
-    clearHighlights: () => {},
   };
   const player = new HumanPlayer(game);
-  const choice = await player.chooseMarine(options);
+  const choice = await player.choose(options);
   assert.deepEqual(choice, options[0]);
   assert.ok(called);
 });
 
 test('RandomAI chooses from options', async () => {
-  const options = [{ x: 1, y: 1 }];
+  const options = [{ type: 'marine', coord: { x: 1, y: 1 } }];
   const ai = new RandomAI();
-  const choice = await ai.chooseMarine(options);
+  const choice = await ai.choose(options);
   assert.deepEqual(choice, options[0]);
 });

--- a/Derelict/Renderer/tsconfig.json
+++ b/Derelict/Renderer/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "outDir": "dist"
   },
-  "include": ["src", "tests"]
+  "include": ["src"]
 }

--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -13,12 +13,25 @@ test('marine moves forward when choosing move', async () => {
   const rules = new BasicRules(board);
   rules.validate(board);
 
+  let calls = 0;
+  let moved;
   const player = {
-    chooseMarine: async (options) => options[0],
-    chooseAction: async () => 'move',
+    choose: async (options) => {
+      calls++;
+      if (calls === 1) {
+        return options[0]; // choose marine
+      }
+      if (calls === 2) {
+        return options.find((o) => o.action === 'move');
+      }
+      moved = { ...board.tokens[0].cells[0] };
+      // After moving once, exit by selecting other and removing marine
+      board.tokens = [];
+      return options.find((o) => o.action === 'selectOther');
+    },
   };
 
   await rules.runGame(player, player);
 
-  assert.deepEqual(board.tokens[0].cells[0], { x: 1, y: 0 });
+  assert.deepEqual(moved, { x: 1, y: 0 });
 });

--- a/Derelict/Rules/types/external.d.ts
+++ b/Derelict/Rules/types/external.d.ts
@@ -11,13 +11,21 @@ declare module 'derelict-boardstate' {
     size: number;
     segments: any[];
     tokens: TokenInstance[];
+    getCellType?(coord: Coord): number;
   }
+  export type Rotation = 0 | 90 | 180 | 270;
 }
 
 declare module 'derelict-players' {
   import type { Coord } from 'derelict-boardstate';
+  export interface Choice {
+    type: 'marine' | 'action';
+    coord?: Coord;
+    action?: 'move' | 'turnLeft' | 'turnRight' | 'selectOther';
+    sprite?: string;
+    rot?: number;
+  }
   export interface Player {
-    chooseMarine(options: Coord[]): Promise<Coord>;
-    chooseAction(options: string[]): Promise<string>;
+    choose(options: Choice[]): Promise<Choice>;
   }
 }


### PR DESCRIPTION
## Summary
- render clickable move and turn sprites so players can act or switch marines directly
- parse sprite manifest to position action buttons in the game UI
- exclude renderer test sources from TypeScript builds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b355225694833389f0b87802a49eb9