### PR TITLE
Fix marine movement rendering in game

### DIFF
--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -134,7 +134,7 @@ async function init() {
   async function startGameFromText(text: string, twoPlayer: boolean) {
     const board = BoardState.newBoard(40, segLib, tokLib);
     BoardState.importBoardText(board, text);
-    const rules = new Rules.BasicRules(board);
+    const rules = new Rules.BasicRules(board, () => renderer.render(board));
     let game!: Game;
     const p1 = new Players.HumanPlayer({
       choose: (options: any) => game.choose(options),

--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -8,7 +8,10 @@ export interface Rules {
 
 // Basic rules implementation allowing a marine to move forward one cell
 export class BasicRules implements Rules {
-  constructor(private board: BoardState) {}
+  constructor(
+    private board: BoardState,
+    private onChange?: (state: BoardState) => void,
+  ) {}
 
   validate(state: BoardState): void {
     const hasMarine = state.tokens.some((t) => t.type === 'marine');
@@ -63,12 +66,15 @@ export class BasicRules implements Rules {
         switch (action.action) {
           case 'move':
             moveForward(token);
+            this.onChange?.(this.board);
             break;
           case 'turnLeft':
             token.rot = (((token.rot + 270) % 360) as Rotation);
+            this.onChange?.(this.board);
             break;
           case 'turnRight':
             token.rot = (((token.rot + 90) % 360) as Rotation);
+            this.onChange?.(this.board);
             break;
           case 'selectOther':
             selecting = false;


### PR DESCRIPTION
## Summary
- Re-render game board after marine moves or turns
- Wire Game to Rules with a board-change callback for redraws

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'jsdom')*
- `npm install jsdom@22.1.0 --no-save` *(fails: Unsupported URL Type "workspace:")*

------
https://chatgpt.com/codex/tasks/task_e_68b42f94b5e48333a5d032bd69b27e52