### PR TITLE
feat(game): implement basic game UI scaffold

### DIFF
--- a/Derelict/Game/src/styles.css
+++ b/Derelict/Game/src/styles.css
@@ -10,6 +10,22 @@ html, body {
   height: 100%;
 }
 
+#top-bar {
+  background: #333;
+  color: #fff;
+  text-align: center;
+  padding: 8px;
+  flex: 0 0 auto;
+}
+
+#buttons {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  background: #ddd;
+  flex: 0 0 auto;
+}
+
 #main {
   flex: 1;
   display: flex;
@@ -29,6 +45,27 @@ html, body {
   height: 100%;
   background: #000;
   display: block;
+}
+
+#side-bar {
+  width: 200px;
+  display: flex;
+  flex-direction: column;
+  background: #ddd;
+}
+
+#action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+}
+
+#status-region {
+  flex: 1;
+  padding: 8px;
+  background: #eee;
+  font-size: 14px;
 }
 
 .modal-overlay {


### PR DESCRIPTION
## Summary
- add top bar and horizontal button bar for new game, save game, and editor links
- add side control panel with action buttons and placeholder status info
- enable saving current board state to a downloadable mission file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4ad40028c8333830ca0259c5bee26