### PR TITLE
Fix forward direction assumption in Rules

### DIFF
--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -92,13 +92,13 @@ function sameCoord(a: Coord, b: Coord): boolean {
 function forwardCell(cell: Coord, rot: Rotation): Coord {
   switch (rot) {
     case 0:
-      return { x: cell.x + 1, y: cell.y };
-    case 90:
       return { x: cell.x, y: cell.y + 1 };
-    case 180:
+    case 90:
       return { x: cell.x - 1, y: cell.y };
-    case 270:
+    case 180:
       return { x: cell.x, y: cell.y - 1 };
+    case 270:
+      return { x: cell.x + 1, y: cell.y };
     default:
       return cell;
   }

--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -33,5 +33,5 @@ test('marine moves forward when choosing move', async () => {
 
   await rules.runGame(player, player);
 
-  assert.deepEqual(moved, { x: 1, y: 0 });
+  assert.deepEqual(moved, { x: 0, y: 1 });
 });


### PR DESCRIPTION
## Summary
- Correct forwardCell orientation so unrotated tokens move along +y
- Update basic rules test to assert new forward direction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4b176abcc83339d3fda17c3d85522