### PR TITLE
Fix game segment highlight bounds and add tests

### DIFF
--- a/Derelict/Game/src/segments.ts
+++ b/Derelict/Game/src/segments.ts
@@ -1,0 +1,30 @@
+export interface SegmentDef {
+  segmentId: string;
+  width: number;
+  height: number;
+  grid: number[][];
+}
+
+// Parse segment definitions from segment library text.
+// Format: "segment <id> <h>x<w>" followed by <h> rows of numbers and an 'endsegment'.
+export function parseSegmentDefs(text: string): SegmentDef[] {
+  const lines = text.split(/\r?\n/);
+  const defs: SegmentDef[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = line.match(/^segment\s+(\S+)\s+(\d+)x(\d+)/);
+    if (m) {
+      const id = m[1];
+      const h = parseInt(m[2], 10);
+      const w = parseInt(m[3], 10);
+      const grid: number[][] = [];
+      for (let r = 0; r < h; r++) {
+        const row = lines[++i];
+        grid.push(row.trim().split(/\s+/).map(Number));
+      }
+      i++; // skip endsegment line
+      defs.push({ segmentId: id, width: w, height: h, grid });
+    }
+  }
+  return defs;
+}

--- a/Derelict/Game/tests/segmentBounds.test.js
+++ b/Derelict/Game/tests/segmentBounds.test.js
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSegmentDefs } from '../dist/src/segments.js';
+import { createRenderer } from '../../Renderer/dist/renderer.js';
+
+test('renderer uses segment dimensions for bounds', () => {
+  const segLib = `segment a 2x2\n1 1\n1 1\nendsegment`;
+  const segmentDefs = parseSegmentDefs(segLib);
+  const board = {
+    size: 5,
+    segments: [
+      { instanceId: 's1', type: 'a', origin: { x: 0, y: 0 }, rot: 0 },
+    ],
+    tokens: [],
+    segmentDefs,
+    getCellType: () => 0,
+  };
+
+  const renderer = createRenderer();
+  renderer.resize(10, 10);
+  renderer.loadSpriteManifestFromText('');
+
+  const calls = { strokeRect: [] };
+  const ctx = {
+    canvas: { width: 10, height: 10 },
+    save() {},
+    restore() {},
+    scale() {},
+    clearRect() {},
+    fillRect() {},
+    drawImage() {},
+    translate() {},
+    rotate() {},
+    strokeRect(...a) {
+      calls.strokeRect.push(a);
+    },
+    lineWidth: 0,
+    strokeStyle: '',
+  };
+
+  const viewport = { origin: { x: 0, y: 0 }, scale: 1, cellSize: 1, dpr: 1 };
+  renderer.render(ctx, board, viewport);
+  assert.equal(calls.strokeRect.length, 1);
+  const [x, y, w, h] = calls.strokeRect[0];
+  assert.equal(w, 2);
+  assert.equal(h, 2);
+  assert.equal(x, 0);
+  assert.equal(y, 0);
+});


### PR DESCRIPTION
## Summary
- parse segment definitions in Game and attach to board so renderer can highlight full multi-cell segments
- add utility to parse segment libraries
- cover segment highlighting with a renderer test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b925cc1c833392a1ca5b95f8534b