### PR TITLE
Replace overlay movement UI with button controls

### DIFF
--- a/Derelict/Game/src/index.ts
+++ b/Derelict/Game/src/index.ts
@@ -6,18 +6,17 @@ export interface RendererLike {
   render(state: BoardState): void;
 }
 
-interface SpriteInfo {
-  file: string;
-  xoff: number;
-  yoff: number;
-}
-
 export interface ChooseUI {
   container: HTMLElement;
   cellToRect: (
     coord: Coord,
   ) => { x: number; y: number; width: number; height: number };
-  sprites: Record<string, SpriteInfo>;
+  buttons: {
+    activate: HTMLButtonElement;
+    move: HTMLButtonElement;
+    turnLeft: HTMLButtonElement;
+    turnRight: HTMLButtonElement;
+  };
 }
 
 // Core game orchestrator providing the GameApi for human players
@@ -53,52 +52,25 @@ export class Game implements GameApi {
     if (!this.ui) return options[0];
 
     return new Promise<Choice>((resolve) => {
-      const elements: HTMLElement[] = [];
-      const cleanup = () => {
-        for (const el of elements) el.remove();
-      };
-
-      const { container, cellToRect, sprites } = this.ui!;
+      const { container, cellToRect, buttons } = this.ui!;
       const key = (c: Coord) => `${c.x},${c.y}`;
+
+      const overlays: { el: HTMLElement; type: 'activate' | 'move' }[] = [];
 
       const marineMap = new Map<string, Choice>();
       for (const opt of options) {
         if (opt.type === 'marine' && opt.coord) marineMap.set(key(opt.coord), opt);
       }
-
       const selectOther = options.find(
         (o) => o.type === 'action' && o.action === 'selectOther',
       );
 
-      for (const opt of options) {
-        if (opt.type === 'action' && opt.coord && opt.sprite) {
-          const rect = cellToRect(opt.coord);
-          const info = sprites[opt.sprite] || { file: opt.sprite, xoff: 0, yoff: 0 };
-          const img = document.createElement('img');
-          img.src = info.file;
-          img.style.position = 'absolute';
-          const cx = rect.x + rect.width / 2;
-          const cy = rect.y + rect.height / 2;
-          const rad = ((opt.rot || 0) * Math.PI) / 180;
-          const ox = info.xoff * Math.cos(rad) - info.yoff * Math.sin(rad);
-          const oy = info.xoff * Math.sin(rad) + info.yoff * Math.cos(rad);
-          img.style.left = `${cx + ox}px`;
-          img.style.top = `${cy + oy}px`;
-          img.style.transform = `translate(-50%, -50%) rotate(${opt.rot || 0}deg)`;
-          img.style.cursor = 'pointer';
-          img.addEventListener('click', (e) => {
-            e.stopPropagation();
-            cleanup();
-            resolve(opt);
-          });
-          container.appendChild(img);
-          elements.push(img);
-        }
-      }
-
-      const marines = this.board.tokens.filter((t) => t.type === 'marine');
-      for (const t of marines) {
-        const coord = t.cells[0];
+      const addOverlay = (
+        coord: Coord,
+        color: string,
+        type: 'activate' | 'move',
+        onClick: () => void,
+      ) => {
         const rect = cellToRect(coord);
         const div = document.createElement('div');
         div.style.position = 'absolute';
@@ -106,22 +78,104 @@ export class Game implements GameApi {
         div.style.top = `${rect.y}px`;
         div.style.width = `${rect.width}px`;
         div.style.height = `${rect.height}px`;
+        div.style.boxSizing = 'border-box';
+        div.style.border = `2px solid ${color}`;
         div.style.cursor = 'pointer';
         div.addEventListener('click', (e) => {
           e.stopPropagation();
-          const m = marineMap.get(key(coord));
-          if (m) {
+          onClick();
+        });
+        container.appendChild(div);
+        overlays.push({ el: div, type });
+      };
+
+      for (const opt of options) {
+        if (opt.type === 'action' && opt.action === 'move' && opt.coord) {
+          addOverlay(opt.coord, 'green', 'move', () => {
+            cleanup();
+            resolve(opt);
+          });
+        }
+      }
+
+      const marines = this.board.tokens.filter((t) => t.type === 'marine');
+      for (const t of marines) {
+        const coord = t.cells[0];
+        const m = marineMap.get(key(coord));
+        if (m) {
+          addOverlay(coord, 'purple', 'activate', () => {
             cleanup();
             resolve(m);
-          } else if (selectOther) {
+          });
+        } else if (selectOther) {
+          addOverlay(coord, 'purple', 'activate', () => {
             this.preselect = coord;
             cleanup();
             resolve(selectOther);
-          }
-        });
-        container.appendChild(div);
-        elements.push(div);
+          });
+        }
       }
+
+      let filter: 'activate' | 'move' | null = null;
+      const setFilter = (f: 'activate' | 'move' | null) => {
+        filter = f;
+        for (const o of overlays) {
+          o.el.style.display = !filter || o.type === filter ? 'block' : 'none';
+        }
+        buttons.activate.classList.toggle('active', filter === 'activate');
+        buttons.move.classList.toggle('active', filter === 'move');
+      };
+
+      function onActivate() {
+        if (buttons.activate.disabled) return;
+        setFilter(filter === 'activate' ? null : 'activate');
+      }
+      function onMove() {
+        if (buttons.move.disabled) return;
+        setFilter(filter === 'move' ? null : 'move');
+      }
+      function onTurnLeft() {
+        const opt = options.find(
+          (o) => o.type === 'action' && o.action === 'turnLeft',
+        );
+        if (opt) {
+          cleanup();
+          resolve(opt);
+        }
+      }
+      function onTurnRight() {
+        const opt = options.find(
+          (o) => o.type === 'action' && o.action === 'turnRight',
+        );
+        if (opt) {
+          cleanup();
+          resolve(opt);
+        }
+      }
+
+      function cleanup() {
+        for (const o of overlays) o.el.remove();
+        buttons.activate.removeEventListener('click', onActivate);
+        buttons.move.removeEventListener('click', onMove);
+        buttons.turnLeft.removeEventListener('click', onTurnLeft);
+        buttons.turnRight.removeEventListener('click', onTurnRight);
+        buttons.activate.classList.remove('active');
+        buttons.move.classList.remove('active');
+      }
+
+      buttons.activate.addEventListener('click', onActivate);
+      buttons.move.addEventListener('click', onMove);
+      buttons.turnLeft.addEventListener('click', onTurnLeft);
+      buttons.turnRight.addEventListener('click', onTurnRight);
+
+      buttons.activate.disabled = !overlays.some((o) => o.type === 'activate');
+      buttons.move.disabled = !overlays.some((o) => o.type === 'move');
+      buttons.turnLeft.disabled = !options.some(
+        (o) => o.type === 'action' && o.action === 'turnLeft',
+      );
+      buttons.turnRight.disabled = !options.some(
+        (o) => o.type === 'action' && o.action === 'turnRight',
+      );
     });
   }
 

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -110,23 +110,21 @@ async function init() {
   actionButtons.id = "action-buttons";
   side.appendChild(actionButtons);
 
-  const actions = [
-    "Move",
-    "Turn Left",
-    "Turn Right",
-    "Manipulate",
-    "Assault",
-    "Shoot / Clear Jam",
-    "Activate Ally",
-    "Overwatch",
-    "Guard",
-    "Pass",
-  ];
-  for (const label of actions) {
-    const b = document.createElement("button");
-    b.textContent = label;
-    actionButtons.appendChild(b);
-  }
+  const btnMove = document.createElement("button");
+  btnMove.textContent = "Move";
+  actionButtons.appendChild(btnMove);
+
+  const btnTurnLeft = document.createElement("button");
+  btnTurnLeft.textContent = "Turn Left";
+  actionButtons.appendChild(btnTurnLeft);
+
+  const btnTurnRight = document.createElement("button");
+  btnTurnRight.textContent = "Turn Right";
+  actionButtons.appendChild(btnTurnRight);
+
+  const btnActivate = document.createElement("button");
+  btnActivate.textContent = "Activate Ally";
+  actionButtons.appendChild(btnActivate);
 
   const status = document.createElement("div");
   status.id = "status-region";
@@ -165,22 +163,7 @@ async function init() {
   // these, so parse them here and attach to the state manually.
   const segmentDefs = parseSegmentDefs(segLib);
   const rendererCore = createRenderer();
-
   rendererCore.loadSpriteManifestFromText(manifestText);
-
-  const spriteInfo: Record<string, { file: string; xoff: number; yoff: number }> = {};
-  for (const line of manifestText.split(/\r?\n/)) {
-    const t = line.trim();
-    if (!t || t.startsWith("#")) continue;
-    const parts = t.split(/\s+/);
-    if (parts.length < 9) continue;
-    const [key, file, , , , , , xoff, yoff] = parts;
-    spriteInfo[key] = {
-      file,
-      xoff: parseInt(xoff, 10) || 0,
-      yoff: parseInt(yoff, 10) || 0,
-    };
-  }
 
   const viewport: any = { origin: { x: 0, y: 0 }, scale: 1, cellSize: 32 };
   let currentState: any = null;
@@ -238,7 +221,12 @@ async function init() {
     game = new Game(board, renderer, rules, p1, p2, {
       container: wrap,
       cellToRect: (coord: any) => rendererCore.boardToScreen(coord, viewport),
-      sprites: spriteInfo,
+      buttons: {
+        activate: btnActivate,
+        move: btnMove,
+        turnLeft: btnTurnLeft,
+        turnRight: btnTurnRight,
+      },
     });
     try {
       await game.start();

--- a/Derelict/Game/src/styles.css
+++ b/Derelict/Game/src/styles.css
@@ -68,6 +68,10 @@ html, body {
   font-size: 14px;
 }
 
+#action-buttons button.active {
+  background: #bbb;
+}
+
 .modal-overlay {
   position: fixed;
   left: 0;

--- a/Derelict/Game/types/external.d.ts
+++ b/Derelict/Game/types/external.d.ts
@@ -21,8 +21,6 @@ declare module 'derelict-players' {
     type: 'marine' | 'action';
     coord?: Coord;
     action?: 'move' | 'turnLeft' | 'turnRight' | 'selectOther';
-    sprite?: string;
-    rot?: number;
   }
   export interface GameApi {
     choose(options: Choice[]): Promise<Choice>;

--- a/Derelict/Players/src/index.ts
+++ b/Derelict/Players/src/index.ts
@@ -5,8 +5,6 @@ export interface Choice {
   type: 'marine' | 'action';
   coord?: Coord;
   action?: 'move' | 'turnLeft' | 'turnRight' | 'selectOther';
-  sprite?: string;
-  rot?: number;
 }
 
 // Game API that players can call to interact with the UI

--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -42,24 +42,10 @@ export class BasicRules implements Rules {
             type: 'action',
             action: 'move',
             coord: forwardCell(token.cells[0], token.rot as Rotation),
-            sprite: 'forward',
-            rot: token.rot,
           });
         }
-        actionChoices.push({
-          type: 'action',
-          action: 'turnLeft',
-          coord: token.cells[0],
-          sprite: 'turn',
-          rot: (token.rot + 270) % 360,
-        });
-        actionChoices.push({
-          type: 'action',
-          action: 'turnRight',
-          coord: token.cells[0],
-          sprite: 'turn',
-          rot: (token.rot + 90) % 360,
-        });
+        actionChoices.push({ type: 'action', action: 'turnLeft' });
+        actionChoices.push({ type: 'action', action: 'turnRight' });
         actionChoices.push({ type: 'action', action: 'selectOther' });
 
         const action = await p1.choose(actionChoices);

--- a/Derelict/Rules/types/external.d.ts
+++ b/Derelict/Rules/types/external.d.ts
@@ -22,8 +22,6 @@ declare module 'derelict-players' {
     type: 'marine' | 'action';
     coord?: Coord;
     action?: 'move' | 'turnLeft' | 'turnRight' | 'selectOther';
-    sprite?: string;
-    rot?: number;
   }
   export interface Player {
     choose(options: Choice[]): Promise<Choice>;


### PR DESCRIPTION
## Summary
- replace sprite overlay controls with button-driven UI
- highlight marines (purple) and move targets (green) with filter buttons
- simplify Choice and rules actions to drop sprite/rot fields

## Testing
- `npm test` (Players)
- `npm test` (Rules)
- `npm test` (Renderer)
- `npm test` (Game)


------
https://chatgpt.com/codex/tasks/task_e_68b4c86caf3c8333b597f1a6f126f8ac