### PR TITLE
Implement pass action and hand off control to second player

### DIFF
--- a/Derelict/Game/docs/SRD.md
+++ b/Derelict/Game/docs/SRD.md
@@ -29,7 +29,8 @@ When this button is pressed the "New Game" dialog is dismissed and the following
 
 1. The BoardState is loaded from the file. 
 2. The Rules object is instanced. 
-3. The two Player objects are instanced.  The first player is always a Human player, the second player is Human or Computer. 
+3. The two Player objects are instanced.  The first player is always a Human player, the second player is Human or Computer.
+   The first player always controls "marine" tokens while the second player controls "alien" tokens.
 4. rules.validate(boardState) is called to check if the boardState is a legitimate starting point for the rules. If this fails, an error message is displayed, and when that is dismissed, we return to a "new game" dialog.
 
 ## UI 
@@ -52,8 +53,8 @@ The UI of the game page is as follows:
 		* The "Shoot / Clear Jam" button
 		* The "Activate Ally" button
 		* The "Overwatch" button
-		* The "Guard" button
-		* The "Pass" button
+                * The "Guard" button
+                * The "Pass" button (always shown last)
 	* A status region showing information like: (We will describe how to populate this later)
 		* "Turn: n"
 		* "Command points: n"
@@ -104,7 +105,7 @@ A keyboard key accelerator listed in the Key column has the same effect as click
 | unjam         | clear jam	 | u	 | none		       | none            | on jam token; this could be rename of shoot button rather than distinct weapon |
 | overwatch     | overwatch  | o	 | none	           | none            | ends activation	|
 | guard	        | guard	     | g	 | none	           | none            | ends activation 	|
-| pass	        | pass	     | x	 | none	           | none            | ends activation 	|
+| pass	        | pass	     | x	 | none	           | none            | ends activation; hands control to the other player |
 
 When a highlighted cell is hovered over (or tapped on a touch device) will show the AP cost of the action in the status region.  Tap devices may need an additional confirm button to tap.
 When the AP cost of a button is zero, the button could perhaps get an additional green highlight.

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -130,6 +130,10 @@ async function init() {
   btnActivate.textContent = "Activate Ally";
   actionButtons.appendChild(btnActivate);
 
+  const btnPass = document.createElement("button");
+  btnPass.textContent = "Pass";
+  actionButtons.appendChild(btnPass);
+
   const status = document.createElement("div");
   status.id = "status-region";
   status.innerHTML =
@@ -225,14 +229,15 @@ async function init() {
     game = new Game(board, renderer, rules, p1, p2, {
       container: wrap,
       cellToRect: (coord: any) => rendererCore.boardToScreen(coord, viewport),
-      buttons: {
-        activate: btnActivate,
-        move: btnMove,
-        turnLeft: btnTurnLeft,
-        turnRight: btnTurnRight,
-        manipulate: btnManipulate,
-      },
-    });
+        buttons: {
+          activate: btnActivate,
+          move: btnMove,
+          turnLeft: btnTurnLeft,
+          turnRight: btnTurnRight,
+          manipulate: btnManipulate,
+          pass: btnPass,
+        },
+      });
     try {
       await game.start();
     } catch (e) {

--- a/Derelict/Game/types/external.d.ts
+++ b/Derelict/Game/types/external.d.ts
@@ -20,7 +20,7 @@ declare module 'derelict-players' {
   export interface Choice {
     type: 'marine' | 'action';
     coord?: Coord;
-    action?: 'move' | 'turnLeft' | 'turnRight' | 'activate' | 'door';
+    action?: 'move' | 'turnLeft' | 'turnRight' | 'activate' | 'door' | 'pass';
   }
   export interface GameApi {
     choose(options: Choice[]): Promise<Choice>;

--- a/Derelict/Players/docs/SRD.md
+++ b/Derelict/Players/docs/SRD.md
@@ -9,6 +9,7 @@ A human player is controlled by the user of the browser via the graphical user i
 A computer player is controlled using simple heuristics. 
 
 Both kinds of player effectively make choices among different options that are presented to them by the game rules.
+These options include a "pass" choice that hands control to the other player.
 
 Players, when asked to make a choice will return it as a Promise. 
 

--- a/Derelict/Players/src/index.ts
+++ b/Derelict/Players/src/index.ts
@@ -4,7 +4,7 @@ import { Coord } from 'derelict-boardstate';
 export interface Choice {
   type: 'marine' | 'action';
   coord?: Coord;
-  action?: 'move' | 'turnLeft' | 'turnRight' | 'activate' | 'door';
+  action?: 'move' | 'turnLeft' | 'turnRight' | 'activate' | 'door' | 'pass';
 }
 
 // Game API that players can call to interact with the UI

--- a/Derelict/Rules/docs/SRD.md
+++ b/Derelict/Rules/docs/SRD.md
@@ -10,10 +10,10 @@ Based on these choices made, the game will progress until one player wins.
 
 Initially the rules of the game are very simple; all this is implemented in the Rules:runGame function: 
 
-* The first player controls the marines.  The second player for the time being does not do anything.
+* The first player controls the marines while the second player controls the aliens.  For the time being, aliens have the same action choices available as marines.
 * The first player must select a cell on the board with a marine in it to activate the marine.  If there are no marines on the board that can be selected, the game is lost and runGame() exits.
-* Once a marine is seledcted, the controlling player may choose to move one cell forward (in the direction the marine is facing) assuming this cell is a corridor and does not contain either a marine or a blip, or turn left, or turn right, or select a different marine to activate it.
-* This selection and movement can continue indefinitely.
+* Once a marine or alien is selected, the controlling player may choose to move one cell forward (in the direction the token is facing) assuming this cell is a corridor and does not contain either a marine or a blip, or turn left, or turn right, or select a different token of the same side to activate it.
+* This selection and movement can continue indefinitely.  At any time, the active player may also choose a "pass" action which ends their activation and hands control to the other player.
 
 This rules module should make the process of choosing for players as simple as possible.  That means that this rules module should examine the boardState and provide an explicit list of possible legal choices
 to players whenever possible.  So above, the Rules should search the board for cells with marines and provide these cells as an explicit list to the player to choose.

--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -91,3 +91,47 @@ test('blocked open door not offered', async () => {
 
   assert.ok(!firstOptions.some((o) => o.action === 'door'));
 });
+
+test('pass hands control to second player who can move alien', async () => {
+  const board = {
+    size: 5,
+    segments: [],
+    tokens: [
+      { instanceId: 'M1', type: 'marine', rot: 0, cells: [{ x: 0, y: 0 }] },
+      { instanceId: 'A1', type: 'alien', rot: 0, cells: [{ x: 2, y: 2 }] },
+    ],
+  };
+  const rules = new BasicRules(board);
+  rules.validate(board);
+
+  let p1Calls = 0;
+  let p2Calls = 0;
+  let moved;
+  const p1 = {
+    choose: async (options) => {
+      p1Calls++;
+      const passOpt = options.find((o) => o.action === 'pass');
+      assert.ok(passOpt);
+      return passOpt;
+    },
+  };
+  const p2 = {
+    choose: async (options) => {
+      p2Calls++;
+      if (p2Calls === 1) {
+        const moveOpt = options.find((o) => o.action === 'move');
+        assert.ok(moveOpt);
+        return moveOpt;
+      }
+      moved = { ...board.tokens.find((t) => t.instanceId === 'A1').cells[0] };
+      board.tokens = [];
+      return options[0];
+    },
+  };
+
+  await rules.runGame(p1, p2);
+
+  assert.equal(p1Calls, 1);
+  assert.ok(p2Calls >= 1);
+  assert.deepEqual(moved, { x: 2, y: 3 });
+});

--- a/Derelict/Rules/types/external.d.ts
+++ b/Derelict/Rules/types/external.d.ts
@@ -21,7 +21,7 @@ declare module 'derelict-players' {
   export interface Choice {
     type: 'marine' | 'action';
     coord?: Coord;
-    action?: 'move' | 'turnLeft' | 'turnRight' | 'activate' | 'door';
+    action?: 'move' | 'turnLeft' | 'turnRight' | 'activate' | 'door' | 'pass';
   }
   export interface Player {
     choose(options: Choice[]): Promise<Choice>;


### PR DESCRIPTION
## Summary
- add always-available `pass` action and allow second player to control aliens
- expose Pass button in game UI and forward choice through Game API
- document new turn passing behaviour and expand tests for both players

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6dedecd3c8333aa5488d51bad46f0