### PR TITLE
Fix sprite scaling for small tokens

### DIFF
--- a/Derelict/Renderer/src/renderer.ts
+++ b/Derelict/Renderer/src/renderer.ts
@@ -56,11 +56,12 @@ export function createRenderer(): Renderer {
       if (image && sprite) {
         ctx.save();
         ctx.translate(rect.x + rect.width / 2, rect.y + rect.height / 2);
-        const sw = sprite.w || (image as any).width || rect.width;
-        const sh = sprite.h || (image as any).height || rect.height;
-        const scaleX = rect.width / sw;
-        const scaleY = rect.height / sh;
-        ctx.translate((sprite.xoff || 0) * scaleX, (sprite.yoff || 0) * scaleY);
+        const sw = sprite.w || (image as any).width || vp.cellSize;
+        const sh = sprite.h || (image as any).height || vp.cellSize;
+        const scale = vp.scale || 1;
+        const dw = sw * scale;
+        const dh = sh * scale;
+        ctx.translate((sprite.xoff || 0) * scale, (sprite.yoff || 0) * scale);
         if (ghost.rot) ctx.rotate((ghost.rot * Math.PI) / 180);
         ctx.drawImage(
           image as any,
@@ -68,10 +69,10 @@ export function createRenderer(): Renderer {
           sprite.y,
           sw,
           sh,
-          -rect.width / 2,
-          -rect.height / 2,
-          rect.width,
-          rect.height,
+          -dw / 2,
+          -dh / 2,
+          dw,
+          dh,
         );
         ctx.restore();
       } else {
@@ -228,11 +229,12 @@ export function createRenderer(): Renderer {
           ctx.save();
           ctx.translate(rect.x + rect.width / 2, rect.y + rect.height / 2);
           if (image && sprite) {
-            const sw = sprite.w || (image as any).width || rect.width;
-            const sh = sprite.h || (image as any).height || rect.height;
-            const scaleX = rect.width / sw;
-            const scaleY = rect.height / sh;
-            ctx.translate((sprite.xoff || 0) * scaleX, (sprite.yoff || 0) * scaleY);
+            const sw = sprite.w || (image as any).width || viewport.cellSize;
+            const sh = sprite.h || (image as any).height || viewport.cellSize;
+            const scale = viewport.scale || 1;
+            const dw = sw * scale;
+            const dh = sh * scale;
+            ctx.translate((sprite.xoff || 0) * scale, (sprite.yoff || 0) * scale);
             if (token.rot) {
               ctx.rotate((token.rot * Math.PI) / 180);
             }
@@ -242,17 +244,18 @@ export function createRenderer(): Renderer {
               sprite.y,
               sw,
               sh,
-              -rect.width / 2,
-              -rect.height / 2,
-              rect.width,
-              rect.height
+              -dw / 2,
+              -dh / 2,
+              dw,
+              dh
             );
           } else {
             if (token.rot) {
               ctx.rotate((token.rot * Math.PI) / 180);
             }
+            const size = viewport.cellSize * (viewport.scale || 1);
             ctx.fillStyle = 'magenta';
-            ctx.fillRect(-rect.width / 2, -rect.height / 2, rect.width, rect.height);
+            ctx.fillRect(-size / 2, -size / 2, size, size);
           }
           ctx.restore();
         };

--- a/Derelict/Renderer/tests/image-size.test.ts
+++ b/Derelict/Renderer/tests/image-size.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+function getPngSize(relPath: string) {
+  const data = readFileSync(new URL(relPath, import.meta.url));
+  return {
+    width: data.readUInt32BE(16),
+    height: data.readUInt32BE(20),
+  };
+}
+
+test('sprite image dimensions', () => {
+  const alien = getPngSize('../../../public/assets/images/alien.png');
+  const deactivated = getPngSize('../../../public/assets/images/deactivated.png');
+  assert.equal(alien.width, 64);
+  assert.equal(alien.height, 64);
+  assert.equal(deactivated.width, 16);
+  assert.equal(deactivated.height, 16);
+});

--- a/Derelict/Renderer/tests/shims.d.ts
+++ b/Derelict/Renderer/tests/shims.d.ts
@@ -1,0 +1,3 @@
+declare module 'node:test';
+declare module 'node:assert/strict';
+declare module 'node:fs';

--- a/Derelict/Renderer/tsconfig.json
+++ b/Derelict/Renderer/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "outDir": "dist"
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary
- prevent token sprites from being forced to cell size
- apply manifest pixel offsets without scaling to cell dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b765bc39948333b4caafadc65e3bff