### PR TITLE
Add rules section to mission files and track turns

### DIFF
--- a/Derelict/BoardState/docs/ChatGPT5-SRD.md
+++ b/Derelict/BoardState/docs/ChatGPT5-SRD.md
@@ -166,6 +166,9 @@ instances:
 
 tokens:
   <tokenId>: <typeName> pos=(x,y) rot=<0|90|180|270> [attrs=<json>]
+
+rules:
+  <key>: <value>
 ```
 
 **Notes**
@@ -174,6 +177,7 @@ tokens:
 * `profile:` lets tools distinguish authored vs saved; BoardState treats both identically.
 * `attrs=<json>` is a single‑line JSON object; unknown keys are preserved on round‑trip.
 * Token positions are **single‑cell**; multi‑cell tokens are a future extension.
+* `rules:` is optional and holds key/value pairs (numbers, booleans, strings) for game rules state such as turn counters.
 
 **Example**
 
@@ -193,6 +197,10 @@ instances:
 tokens:
   D1: door   pos=(13,12) rot=90
   M1: marine pos=(11,12) rot=180 attrs={"owner":"red","name":"Sergeant"}
+
+rules:
+  turn: 3
+  activeplayer: 1
 ```
 
 ---

--- a/Derelict/BoardState/src/api/public.ts
+++ b/Derelict/BoardState/src/api/public.ts
@@ -3,6 +3,7 @@ import { parseSegmentLibrary } from '../io/segmentLib.parse.js';
 import { parseTokenLibrary } from '../io/tokenLib.parse.js';
 import { parseMission } from '../io/mission.parse.js';
 import { serializeMission } from '../io/mission.serialize.js';
+export type { MissionData } from '../io/mission.parse.js';
 import { createState, resetBoard, placeSegment, removeSegmentAtCoordInternal, placeToken, removeTokenInternal, cellTypeAt, cellsInSameSegment, tokensAt, findByIdInternal } from '../core/boardState.js';
 
 export function newBoard(size: number, segmentLibrary: string, tokenLibrary: string): BoardState {
@@ -13,7 +14,7 @@ export function newBoard(size: number, segmentLibrary: string, tokenLibrary: str
   return state;
 }
 
-export function importBoardText(state: BoardState, text: string): void {
+export function importBoardText(state: BoardState, text: string) {
   const mission = parseMission(text);
   resetBoard(state as any, mission.size || state.size);
   for (const s of mission.segments) {
@@ -22,10 +23,15 @@ export function importBoardText(state: BoardState, text: string): void {
   for (const t of mission.tokens) {
     placeToken(state as any, t);
   }
+  return mission;
 }
 
-export function exportBoardText(state: BoardState, missionName: string): string {
-  return serializeMission(state, missionName);
+export function exportBoardText(
+  state: BoardState,
+  missionName: string,
+  extras?: { rules?: Record<string, unknown> },
+): string {
+  return serializeMission(state, missionName, extras);
 }
 
 // Mutations

--- a/Derelict/BoardState/src/io/mission.serialize.ts
+++ b/Derelict/BoardState/src/io/mission.serialize.ts
@@ -1,6 +1,10 @@
 import { BoardState } from '../core/types.js';
 
-export function serializeMission(state: BoardState, missionName = 'Untitled'): string {
+export function serializeMission(
+  state: BoardState,
+  missionName = 'Untitled',
+  extras?: { rules?: Record<string, unknown> },
+): string {
   const lines: string[] = [];
   lines.push(`mission: ${missionName}`);
   lines.push(`profile: mission`);
@@ -21,6 +25,14 @@ export function serializeMission(state: BoardState, missionName = 'Untitled'): s
     const pos = t.cells[0];
     const attr = t.attrs ? ` attrs=${JSON.stringify(t.attrs)}` : '';
     lines.push(`  ${t.instanceId}: ${t.type} pos=(${pos.x},${pos.y}) rot=${t.rot}${attr}`);
+  }
+  if (extras?.rules && Object.keys(extras.rules).length > 0) {
+    lines.push('');
+    lines.push('rules:');
+    const keys = Object.keys(extras.rules).sort();
+    for (const key of keys) {
+      lines.push(`  ${key}: ${extras.rules[key]}`);
+    }
   }
   return lines.join('\n');
 }

--- a/Derelict/BoardState/tests/mission.test.js
+++ b/Derelict/BoardState/tests/mission.test.js
@@ -43,5 +43,15 @@ describe('mission import/export', () => {
     board.tokens.push({ type: 'door', rot: 0, cells: [{ x: 0, y: 0 }] });
     assert.doesNotThrow(() => exportBoardText(board, 'Test'));
   });
-});
+
+  it('parses and serializes rules section', () => {
+    const board = newBoard(40, segLib, tokLib);
+    const textWithRules = missionText + '\n\nrules:\n  turn: 3\n  activeplayer: 2\n';
+    const mission = importBoardText(board, textWithRules);
+    assert.equal(mission.rules.turn, 3);
+    assert.equal(mission.rules.activeplayer, 2);
+    const out = exportBoardText(board, 'Test', { rules: mission.rules });
+      assert.match(out, /rules:\n  activeplayer: 2\n  turn: 3/);
+    });
+  });
 

--- a/Derelict/Editor/docs/SRD.md
+++ b/Derelict/Editor/docs/SRD.md
@@ -42,6 +42,7 @@ Provide a browser-based **mission editor** for the Derelict game, separated from
 - Unselect: cancel ghosting, return to selection mode.
 - File operations via modals (New, Load, Save, Play).
 - Confirming **New** clears the board and resets the mission name to "Unnamed Mission".
+ - When loading a mission file that contains a `rules` section (from a saved game), the extra data is ignored.
 - Renderer updates after each change to BoardState.
 
 ## 5. Non-Functional Requirements

--- a/Derelict/Game/docs/SRD.md
+++ b/Derelict/Game/docs/SRD.md
@@ -11,10 +11,10 @@ The Game Module interacts with the following other modules:
 	An object implementing the Rules interface, that implements the board game's rules.
 	
 At startup, the user is presented with the "New Game" modal dialog with the following fields:
-1. A list box showing the available server side mission files (the contents of Derelict/public/missions) 
-	The game.html URL parameters are inspected.  Using parameters, it is possible to pre-select a specific server side mission file to start. In this case the appropriate item in the list box is highlighted.
-	
-	There is also a text prompt: "Drag and Drop a savegame file here to load it!" Dropping a legal savegame file will gray the mission selection and display the name of the savegame file about to be loaded. 
+1. A list box showing the available server side mission files (the contents of Derelict/public/missions)
+        The game.html URL parameters are inspected.  Using parameters, it is possible to pre-select a specific server side mission file to start. In this case the appropriate item in the list box is highlighted.
+
+        There is also a text prompt: "Drag and Drop a savegame file here to load it!" Dropping a legal savegame file will gray the mission selection and display the name of the savegame file about to be loaded. Savegames are mission files with an optional `rules` section that records state such as the current turn and active player.
 
 2. A pair of radio buttons to choose "Single Player" or "Two Player" game.
 	We can either have hot seat (2 human) multiplayer or human vs computer controlled enemies. 
@@ -40,7 +40,7 @@ The UI of the game page is as follows:
 * Horizontal bar at the top saying "Derelict Game", just like we have in Editor.
 * Horizontal Button Bar with buttons: "New Game", "Save Game", "Editor", same style like we have in Editor.
 	* The "New Game" button that when pressed, after modal confirmation dialog that gives a chance to cance, start a new game returns us to a "new game" dialog as above.
-	* The "Save Game" button saves the BoardState to a mission file (that gets downloaded to the user's computer.
+        * The "Save Game" button saves the BoardState and current Rules state (e.g. turn and active player) to a mission file that gets downloaded to the user's computer.
 	* The "Editor" button, that when pressed, after modal confirmation dialog that gives a chance to cancel, forwards to index.html which is the editor page. 		
 * The play area viewport that uses the Renderer to display the boardState.
 * A vertical bar to the right of the play area viewport that is horizontally divided into two regions:
@@ -55,14 +55,15 @@ The UI of the game page is as follows:
 		* The "Overwatch" button
                 * The "Guard" button
                 * The "Pass" button (always shown last)
-	* A status region showing information like: (We will describe how to populate this later)
-		* "Turn: n"
-		* "Command points: n"
-		* "Activated Unit Name: xyz" 
-		* "Activated Unit Role: xyz" 
-		* "AP remaining: n"
-		* "AP for action: n" 
-		* "Ammo remaining: n" 
+        * A status region showing information like: (We will describe how to populate this later)
+                * "Turn: n"
+                * "Active player: n"
+                * "Command points: n"
+                * "Activated Unit Name: xyz"
+                * "Activated Unit Role: xyz"
+                * "AP remaining: n"
+                * "AP for action: n"
+                * "Ammo remaining: n"
 	
 ## Control FLow
 

--- a/Derelict/Game/tests/asset-loading.test.js
+++ b/Derelict/Game/tests/asset-loading.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createRenderer } from '../../Renderer/dist/renderer.js';
+import { createRenderer } from '../../Renderer/dist/src/renderer.js';
 
 test('renderer re-renders after image load', async () => {
   class FakeImage {

--- a/Derelict/Game/tests/segmentBounds.test.js
+++ b/Derelict/Game/tests/segmentBounds.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { parseSegmentDefs } from '../dist/src/segments.js';
-import { createRenderer } from '../../Renderer/dist/renderer.js';
+import { createRenderer } from '../../Renderer/dist/src/renderer.js';
 
 test('renderer uses segment dimensions for bounds', () => {
   const segLib = `segment a 2x2\n1 1\n1 1\nendsegment`;


### PR DESCRIPTION
## Summary
- document optional `rules` block in mission files and sort keys for deterministic output
- note mission save/load rules info in BoardState, Game, and Editor SRDs and fix renderer test imports

## Testing
- `cd BoardState && npm test`
- `cd Rules && npm test`
- `cd Renderer && npm run build`
- `cd Game && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9828a54bc8333b83919b5dceebb86