### PR TITLE
Implement line of sight rules and restrict blip movement

### DIFF
--- a/Derelict/Rules/docs/SRD.txt
+++ b/Derelict/Rules/docs/SRD.txt
@@ -1,0 +1,22 @@
+Line of Sight
+-------------
+Line of sight between two cells exists when every cell touched by the Bresenham line
+algorithm between them is free of obstructions. A cell is obstructed if it is not a
+corridor cell or contains a blocking token such as a closed door, marine, alien or
+blip. When the line steps diagonally between two cells, at least one of the two
+adjacent off-diagonal cells must also be unobstructed; otherwise line of sight is
+blocked.
+
+Marine Field of View
+--------------------
+Marines can only see within a 90-degree arc centered on their facing direction.
+Cells outside this field of view are never considered visible to the marine,
+even if unobstructed.
+
+Blip Movement Restriction
+-------------------------
+Blips may not move into any cell that has line of sight to a cell containing a
+marine. This uses the marine's field of view and line-of-sight rules above.
+Blips also cannot move into any of the eight cells directly adjacent to a
+marine, regardless of visibility. The rules filter available blip movement
+options to enforce these restrictions.


### PR DESCRIPTION
## Summary
- add marine forward-arc check to line of sight calculations
- filter blip movement options using marine field of view and proximity restrictions
- document marine field of view and blip proximity rules in the SRD

## Testing
- `npm test --prefix Rules`


------
https://chatgpt.com/codex/tasks/task_e_68bab9037f688333afcd649e093ccfa9