### PR TITLE
Allow diagonal movement for all units

### DIFF
--- a/Derelict/Rules/docs/SRD.md
+++ b/Derelict/Rules/docs/SRD.md
@@ -14,7 +14,7 @@ Initially the rules of the game are very simple; all this is implemented in the 
 
 * The first player controls the marines while the second player controls the aliens and blips.  For the time being, aliens and blips have the same action choices available as marines.
 * The first player must select a cell on the board with a marine in it to activate the marine, or pass, which yields control to the other player.  If there are no marines on the board that can be selected, the game is lost and runGame() exits.
-* Once a marine, alien, or blip is selected, the controlling player may choose to move one cell forward (in the direction the token is facing) assuming this cell is a corridor and does not contain a marine, alien, or blip, or turn left, or turn right, or select a different token of the same side to activate it.
+* Once a marine, alien, or blip is selected, the controlling player may choose to move one cell forward (in the direction the token is facing), move one cell diagonally forward, move one cell backward, or move one cell diagonally backward (each subject to the appropriate AP cost) assuming the destination cell is a corridor and does not contain a marine, alien, or blip, or turn left, or turn right, or select a different token of the same side to activate it.
 * Marines, blips and aliens all block movement for each other.
 * This selection and movement can continue indefinitely.  At any time, the active player may also choose a "pass" action which ends their activation and hands control to the other player.
 
@@ -49,6 +49,8 @@ The following table lists all the different actions (choices) that are available
 | assault       | 1           | 1         | -        |       |
 | move forward  | 1           | 1         | 1        |       |
 | move backward | 2           | 2         | 1        |       |
+| move forward diagonal | 1 | 1 | 1 | Moves one cell forward-left or forward-right. |
+| move backward diagonal | 2 | 2 | 1 | Moves one cell backward-left or backward-right. |
 | move sideways | -           | 1         | 1        |       |
 | door open     | 1           | 1         | 1        |       |
 | door close    | 1           | 1         | 1        |       |

--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -279,19 +279,31 @@ function moveToken(token: TokenInstance, target: Coord): void {
   token.cells = token.cells.map((c) => ({ x: c.x + dx, y: c.y + dy }));
 }
 
-function getMoveOptions(board: BoardState, token: TokenInstance): { coord: Coord; cost: number }[] {
+export function getMoveOptions(board: BoardState, token: TokenInstance): { coord: Coord; cost: number }[] {
   const rot = token.rot as Rotation;
   const pos = token.cells[0];
   let res: { coord: Coord; cost: number }[] = [];
   const forward = forwardCell(pos, rot);
+  const forwardLeft = leftCell(forward, rot);
+  const forwardRight = rightCell(forward, rot);
   if (canMoveTo(board, forward)) res.push({ coord: forward, cost: 1 });
+  if (canMoveTo(board, forwardLeft)) res.push({ coord: forwardLeft, cost: 1 });
+  if (canMoveTo(board, forwardRight)) res.push({ coord: forwardRight, cost: 1 });
   const backward = backwardCell(pos, rot);
+  const backwardLeft = leftCell(backward, rot);
+  const backwardRight = rightCell(backward, rot);
   if (token.type === 'marine') {
     if (canMoveTo(board, backward)) res.push({ coord: backward, cost: 2 });
+    if (canMoveTo(board, backwardLeft)) res.push({ coord: backwardLeft, cost: 2 });
+    if (canMoveTo(board, backwardRight)) res.push({ coord: backwardRight, cost: 2 });
   } else if (token.type === 'alien') {
     if (canMoveTo(board, backward)) res.push({ coord: backward, cost: 2 });
+    if (canMoveTo(board, backwardLeft)) res.push({ coord: backwardLeft, cost: 2 });
+    if (canMoveTo(board, backwardRight)) res.push({ coord: backwardRight, cost: 2 });
   } else if (token.type === 'blip') {
     if (canMoveTo(board, backward)) res.push({ coord: backward, cost: 1 });
+    if (canMoveTo(board, backwardLeft)) res.push({ coord: backwardLeft, cost: 1 });
+    if (canMoveTo(board, backwardRight)) res.push({ coord: backwardRight, cost: 1 });
   }
   if (token.type === 'alien' || token.type === 'blip') {
     const left = leftCell(pos, rot);

--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { BasicRules, hasLineOfSight, marineHasLineOfSight } from '../dist/src/index.js';
+import { BasicRules, hasLineOfSight, marineHasLineOfSight, getMoveOptions } from '../dist/src/index.js';
 
 test('marine moves forward when choosing move', async () => {
   const board = {
@@ -593,4 +593,54 @@ test('blip cannot move adjacent to marine', async () => {
       (o) => o.action === 'move' && o.coord?.x === 1 && o.coord?.y === 1,
     ),
   );
+});
+
+test('getMoveOptions adds diagonal moves for marine', () => {
+  const board = {
+    size: 5,
+    segments: [],
+    tokens: [
+      { instanceId: 'M1', type: 'marine', rot: 0, cells: [{ x: 2, y: 2 }] },
+    ],
+  };
+  const moves = getMoveOptions(board, board.tokens[0]);
+  const coords = moves.map((m) => `${m.coord.x},${m.coord.y}:${m.cost}`);
+  assert.ok(coords.includes('1,3:1'));
+  assert.ok(coords.includes('3,3:1'));
+  assert.ok(coords.includes('1,1:2'));
+  assert.ok(coords.includes('3,1:2'));
+});
+
+test('getMoveOptions adds diagonal moves for alien', () => {
+  const board = {
+    size: 5,
+    segments: [],
+    tokens: [
+      { instanceId: 'A1', type: 'alien', rot: 0, cells: [{ x: 2, y: 2 }] },
+      { instanceId: 'M1', type: 'marine', rot: 0, cells: [{ x: 0, y: 0 }] },
+    ],
+  };
+  const moves = getMoveOptions(board, board.tokens[0]);
+  const coords = moves.map((m) => `${m.coord.x},${m.coord.y}:${m.cost}`);
+  assert.ok(coords.includes('1,3:1'));
+  assert.ok(coords.includes('3,3:1'));
+  assert.ok(coords.includes('1,1:2'));
+  assert.ok(coords.includes('3,1:2'));
+});
+
+test('getMoveOptions adds diagonal moves for blip', () => {
+  const board = {
+    size: 5,
+    segments: [],
+    tokens: [
+      { instanceId: 'B1', type: 'blip', rot: 0, cells: [{ x: 1, y: 2 }] },
+      { instanceId: 'M1', type: 'marine', rot: 0, cells: [{ x: 4, y: 4 }] },
+    ],
+  };
+  const moves = getMoveOptions(board, board.tokens[0]);
+  const coords = moves.map((m) => `${m.coord.x},${m.coord.y}:${m.cost}`);
+  assert.ok(coords.includes('0,3:1'));
+  assert.ok(coords.includes('2,3:1'));
+  assert.ok(coords.includes('0,1:1'));
+  assert.ok(coords.includes('2,1:1'));
 });


### PR DESCRIPTION
## Summary
- Allow units to move diagonally forward and backward at the same AP cost as straight movement
- Document new diagonal movement rules in SRD
- Export getMoveOptions and add tests for diagonal movement options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3db44ef88333b30c4d7be82136fb