### PR TITLE
Apply blip rules to all blip token variants

### DIFF
--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -47,7 +47,7 @@ export class BasicRules implements Rules {
     this.emitStatus();
     while (true) {
       const tokens = this.board.tokens.filter((t) =>
-        currentSide === 'marine' ? t.type === 'marine' : t.type === 'alien' || t.type === 'blip',
+        currentSide === 'marine' ? t.type === 'marine' : t.type === 'alien' || isBlip(t),
       );
       if (tokens.length === 0) return;
       if (!active || !tokens.includes(active) || hasDeactivatedToken(this.board, active.cells[0])) {
@@ -300,18 +300,18 @@ export function getMoveOptions(board: BoardState, token: TokenInstance): { coord
     if (canMoveTo(board, backward)) res.push({ coord: backward, cost: 2 });
     if (canMoveTo(board, backwardLeft)) res.push({ coord: backwardLeft, cost: 2 });
     if (canMoveTo(board, backwardRight)) res.push({ coord: backwardRight, cost: 2 });
-  } else if (token.type === 'blip') {
+  } else if (isBlip(token)) {
     if (canMoveTo(board, backward)) res.push({ coord: backward, cost: 1 });
     if (canMoveTo(board, backwardLeft)) res.push({ coord: backwardLeft, cost: 1 });
     if (canMoveTo(board, backwardRight)) res.push({ coord: backwardRight, cost: 1 });
   }
-  if (token.type === 'alien' || token.type === 'blip') {
+  if (token.type === 'alien' || isBlip(token)) {
     const left = leftCell(pos, rot);
     if (canMoveTo(board, left)) res.push({ coord: left, cost: 1 });
     const right = rightCell(pos, rot);
     if (canMoveTo(board, right)) res.push({ coord: right, cost: 1 });
   }
-  if (token.type === 'blip') {
+  if (isBlip(token)) {
     const marines = board.tokens.filter((t) => t.type === 'marine');
     res = res.filter(
       (mv) =>
@@ -326,22 +326,15 @@ export function getMoveOptions(board: BoardState, token: TokenInstance): { coord
 }
 
 function initialAp(token: TokenInstance): number {
-  switch (token.type) {
-    case 'marine':
-      return 4;
-    case 'alien':
-      return 6;
-    case 'blip':
-      return 6;
-    default:
-      return 0;
-  }
+  if (token.type === 'marine') return 4;
+  if (token.type === 'alien' || isBlip(token)) return 6;
+  return 0;
 }
 
 function getTurnCost(token: TokenInstance, lastMove: boolean): number {
   if (token.type === 'marine') return 1;
   if (token.type === 'alien') return lastMove ? 0 : 1;
-  if (token.type === 'blip') return 0;
+  if (isBlip(token)) return 0;
   return 1;
 }
 
@@ -382,8 +375,12 @@ function rightCell(cell: Coord, rot: Rotation): Coord {
   }
 }
 
+function isBlip(t: { type: string }): boolean {
+  return t.type.startsWith('blip');
+}
+
 function isUnit(t: { type: string }): boolean {
-  return t.type === 'marine' || t.type === 'alien' || t.type === 'blip';
+  return t.type === 'marine' || t.type === 'alien' || isBlip(t);
 }
 
 function blocksMovement(t: TokenInstance): boolean {
@@ -467,7 +464,7 @@ function isObstructed(
 }
 
 function blocksSight(t: TokenInstance): boolean {
-  return t.type === 'door' || t.type === 'marine' || t.type === 'alien' || t.type === 'blip';
+  return t.type === 'door' || t.type === 'marine' || t.type === 'alien' || isBlip(t);
 }
 
 function rotVector(rot: Rotation): { x: number; y: number } {

--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -481,43 +481,45 @@ test('marineHasLineOfSight limited to forward arc', () => {
   );
 });
 
-test('blip cannot move into line of sight of marine', async () => {
-  const board = {
-    size: 5,
-    segments: [],
-    tokens: [
-      { instanceId: 'B1', type: 'blip', rot: 0, cells: [{ x: 0, y: 0 }] },
-      { instanceId: 'M1', type: 'marine', rot: 180, cells: [{ x: 0, y: 3 }] },
-    ],
-  };
-  const rules = new BasicRules(board, undefined, undefined, { activePlayer: 2 });
-  rules.validate(board);
+for (const blipType of ['blip', 'blip_2', 'blip_3']) {
+  test(`${blipType} cannot move into line of sight of marine`, async () => {
+    const board = {
+      size: 5,
+      segments: [],
+      tokens: [
+        { instanceId: 'B1', type: blipType, rot: 0, cells: [{ x: 0, y: 0 }] },
+        { instanceId: 'M1', type: 'marine', rot: 180, cells: [{ x: 0, y: 3 }] },
+      ],
+    };
+    const rules = new BasicRules(board, undefined, undefined, { activePlayer: 2 });
+    rules.validate(board);
 
-  let calls = 0;
-  let moveOptions;
-  const p1 = { choose: async () => ({ type: 'action', action: 'pass' }) };
-  const p2 = {
-    choose: async (options) => {
-      calls++;
-      if (calls === 1) {
-        return options.find(
-          (o) => o.action === 'activate' && o.coord?.x === 0 && o.coord?.y === 0,
-        );
-      }
-      moveOptions = options;
-      board.tokens = [];
-      return options.find((o) => o.action === 'pass');
-    },
-  };
+    let calls = 0;
+    let moveOptions;
+    const p1 = { choose: async () => ({ type: 'action', action: 'pass' }) };
+    const p2 = {
+      choose: async (options) => {
+        calls++;
+        if (calls === 1) {
+          return options.find(
+            (o) => o.action === 'activate' && o.coord?.x === 0 && o.coord?.y === 0,
+          );
+        }
+        moveOptions = options;
+        board.tokens = [];
+        return options.find((o) => o.action === 'pass');
+      },
+    };
 
-  await rules.runGame(p1, p2);
+    await rules.runGame(p1, p2);
 
-  assert.ok(
-    !moveOptions.some(
-      (o) => o.action === 'move' && o.coord?.x === 0 && o.coord?.y === 1,
-    ),
-  );
-});
+    assert.ok(
+      !moveOptions.some(
+        (o) => o.action === 'move' && o.coord?.x === 0 && o.coord?.y === 1,
+      ),
+    );
+  });
+}
 
 test('blip can move outside marine field of view', async () => {
   const board = {
@@ -628,19 +630,21 @@ test('getMoveOptions adds diagonal moves for alien', () => {
   assert.ok(coords.includes('3,1:2'));
 });
 
-test('getMoveOptions adds diagonal moves for blip', () => {
-  const board = {
-    size: 5,
-    segments: [],
-    tokens: [
-      { instanceId: 'B1', type: 'blip', rot: 0, cells: [{ x: 1, y: 2 }] },
-      { instanceId: 'M1', type: 'marine', rot: 0, cells: [{ x: 4, y: 4 }] },
-    ],
-  };
-  const moves = getMoveOptions(board, board.tokens[0]);
-  const coords = moves.map((m) => `${m.coord.x},${m.coord.y}:${m.cost}`);
-  assert.ok(coords.includes('0,3:1'));
-  assert.ok(coords.includes('2,3:1'));
-  assert.ok(coords.includes('0,1:1'));
-  assert.ok(coords.includes('2,1:1'));
-});
+for (const blipType of ['blip', 'blip_2', 'blip_3']) {
+  test(`getMoveOptions adds diagonal moves for ${blipType}`, () => {
+    const board = {
+      size: 5,
+      segments: [],
+      tokens: [
+        { instanceId: 'B1', type: blipType, rot: 0, cells: [{ x: 1, y: 2 }] },
+        { instanceId: 'M1', type: 'marine', rot: 0, cells: [{ x: 4, y: 4 }] },
+      ],
+    };
+    const moves = getMoveOptions(board, board.tokens[0]);
+    const coords = moves.map((m) => `${m.coord.x},${m.coord.y}:${m.cost}`);
+    assert.ok(coords.includes('0,3:1'));
+    assert.ok(coords.includes('2,3:1'));
+    assert.ok(coords.includes('0,1:1'));
+    assert.ok(coords.includes('2,1:1'));
+  });
+}


### PR DESCRIPTION
## Summary
- treat tokens beginning with `blip` as blips across rules
- test blip_2 and blip_3 variants for movement and line-of-sight restrictions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc87bd863c8333aaad5c596ffb32a4