### PR TITLE
Handle involuntary blip reveals and clarify active player

### DIFF
--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -186,7 +186,10 @@ async function init() {
 
   const updateStatus = (info: { turn: number; activePlayer: number; ap?: number }) => {
     statusTurn.textContent = `Turn: ${info.turn}`;
-    statusPlayer.textContent = `Active Player: ${info.activePlayer}`;
+    statusPlayer.textContent =
+      info.activePlayer === 1
+        ? "Active Player: 1 (Marines)"
+        : "Active Player: 2 (Aliens)";
     statusAP.textContent =
       typeof info.ap === "number" ? `AP remaining: ${info.ap}` : "";
   };


### PR DESCRIPTION
## Summary
- Add logic to detect when marines gain line of sight to blips and force an involuntary reveal, allowing marine placement and alien orientation
- Trigger visibility checks after moves, turns, and doors, and permit deploying revealed aliens into visible adjacent cells
- Show the active player as "Marines" or "Aliens" in the game status panel for clarity

## Testing
- `cd Rules && npm test`
- `cd Renderer && npm run build`
- `cd Game && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf23c974e083338df8609f6478335c