### PR TITLE
Treat marine_* tokens as standard marines

### DIFF
--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -35,6 +35,39 @@ test('marine moves forward when choosing move', async () => {
   assert.deepEqual(moved, { x: 0, y: 1 });
 });
 
+test('marine_flame moves forward when choosing move', async () => {
+  const board = {
+    size: 5,
+    segments: [],
+    tokens: [
+      { instanceId: 'M1', type: 'marine_flame', rot: 0, cells: [{ x: 0, y: 0 }] },
+    ],
+  };
+  const rules = new BasicRules(board);
+  rules.validate(board);
+
+  let calls = 0;
+  let moved;
+  const player = {
+    choose: async (options) => {
+      calls++;
+      if (calls === 1) {
+        return options.find((o) => o.action === 'activate');
+      }
+      if (calls === 2) {
+        return options.find((o) => o.action === 'move');
+      }
+      moved = { ...board.tokens[0].cells[0] };
+      board.tokens = [];
+      return options[0];
+    },
+  };
+
+  await rules.runGame(player, player);
+
+  assert.deepEqual(moved, { x: 0, y: 1 });
+});
+
 test('door action toggles door', async () => {
   const board = {
     size: 5,


### PR DESCRIPTION
## Summary
- recognize any token whose type starts with `marine` as a marine
- use new `isMarine` helper in rules for movement, action points, unit checks and blocking
- test movement of `marine_flame` token

## Testing
- `cd Derelict/Rules && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3251923108333b4a54c88cd3562b7