### PR TITLE
Add game log and logging API

### DIFF
--- a/Derelict/Game/src/index.ts
+++ b/Derelict/Game/src/index.ts
@@ -37,6 +37,7 @@ export class Game implements GameApi {
     private player1: Player,
     private player2: Player,
     private ui?: ChooseUI,
+    private logger?: (msg: string, color?: string) => void,
   ) {}
 
   async start(): Promise<void> {
@@ -355,6 +356,10 @@ export class Game implements GameApi {
   // Clean up any in-progress UI interactions
   dispose(): void {
     this.cleanup?.();
+  }
+
+  log(message: string, color?: string): void {
+    this.logger?.(message, color);
   }
 
   async messageBox(_message: string): Promise<boolean> {

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -94,13 +94,21 @@ async function init() {
   main.id = "main";
   app.appendChild(main);
 
+  const play = document.createElement("div");
+  play.id = "play-area";
+  main.appendChild(play);
+
   const wrap = document.createElement("div");
   wrap.id = "viewport-wrap";
-  main.appendChild(wrap);
+  play.appendChild(wrap);
 
   const canvas = document.createElement("canvas");
   canvas.id = "viewport";
   wrap.appendChild(canvas);
+
+  const logArea = document.createElement("div");
+  logArea.id = "log";
+  play.appendChild(logArea);
 
   const side = document.createElement("div");
   side.id = "side-bar";
@@ -185,6 +193,14 @@ async function init() {
   let currentRules: any = null;
   let currentGame: Game | null = null;
 
+  const logMessage = (text: string, color?: string) => {
+    const span = document.createElement("span");
+    if (color) span.style.color = color;
+    span.textContent = text + " ";
+    logArea.appendChild(span);
+    logArea.scrollLeft = logArea.scrollWidth;
+  };
+
   const updateStatus = (info: {
     turn: number;
     activePlayer: number;
@@ -232,6 +248,7 @@ async function init() {
 
   async function startGameFromText(text: string, twoPlayer: boolean) {
     currentGame?.dispose();
+    logArea.textContent = "";
     const board: any = BoardState.newBoard(40, segLib, tokLib);
     // ensure renderer knows dimensions for each segment
     board.segmentDefs = segmentDefs;
@@ -248,6 +265,7 @@ async function init() {
       () => renderer.render(board),
       updateStatus,
       { turn: initTurn, activePlayer: initPlayer },
+      logMessage,
     );
     currentRules = rules;
     updateStatus(rules.getState());
@@ -255,11 +273,13 @@ async function init() {
     const p1 = new Players.HumanPlayer({
       choose: (options: any) => game.choose(options),
       messageBox: (msg: string) => game.messageBox(msg),
+      log: (msg: string, color?: string) => game.log(msg, color),
     });
     const p2 = twoPlayer
       ? new Players.HumanPlayer({
           choose: (options: any) => game.choose(options),
           messageBox: (msg: string) => game.messageBox(msg),
+          log: (msg: string, color?: string) => game.log(msg, color),
         })
       : new Players.RandomAI();
     game = new Game(board, renderer, rules, p1, p2, {
@@ -275,7 +295,7 @@ async function init() {
         deploy: btnDeploy,
         pass: btnPass,
       },
-    });
+    }, logMessage);
     currentGame = game;
     try {
       await game.start();

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -104,6 +104,8 @@ async function init() {
 
   const canvas = document.createElement("canvas");
   canvas.id = "viewport";
+  canvas.width = 2560;
+  canvas.height = 2560;
   wrap.appendChild(canvas);
 
   const logArea = document.createElement("div");
@@ -216,12 +218,12 @@ async function init() {
   };
   function render(state: any) {
     currentState = state;
-    const rect = canvas.getBoundingClientRect();
-    canvas.width = rect.width;
-    canvas.height = rect.height;
-    rendererCore.resize(rect.width, rect.height);
+    const size = 2560;
+    canvas.width = size;
+    canvas.height = size;
+    rendererCore.resize(size, size);
     viewport.dpr = window.devicePixelRatio || 1;
-    const base = Math.min(rect.width, rect.height) / state.size;
+    const base = size / state.size;
     viewport.cellSize = Math.min(base, 64);
     rendererCore.render(ctx, state, viewport);
   }

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -196,11 +196,12 @@ async function init() {
   let currentGame: Game | null = null;
 
   const logMessage = (text: string, color?: string) => {
-    const span = document.createElement("span");
-    if (color) span.style.color = color;
-    span.textContent = text + " ";
-    logArea.appendChild(span);
+    const line = document.createElement("div");
+    if (color) line.style.color = color;
+    line.textContent = text;
+    logArea.appendChild(line);
     logArea.scrollLeft = logArea.scrollWidth;
+    logArea.scrollTop = logArea.scrollHeight;
   };
 
   const updateStatus = (info: {

--- a/Derelict/Game/src/styles.css
+++ b/Derelict/Game/src/styles.css
@@ -30,34 +30,33 @@ html, body {
   flex: 1;
   display: flex;
   position: relative;
-  overflow: hidden;
 }
 
 #play-area {
+  flex: 1 1 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: 2560px;
-  overflow: hidden;
 }
 
 #viewport-wrap {
   position: relative;
   flex: 1 1 auto;
-  width: 2560px;
-  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
 }
 
 #viewport {
-  width: 100%;
-  height: 100%;
+  width: 2560px;
+  height: 2560px;
   background: #000;
   display: block;
 }
 
 #log {
-  flex: none;
-  height: 80px;
+  flex: 0 0 80px;
   background: #111;
   color: #fff;
   overflow-x: auto;
@@ -67,7 +66,7 @@ html, body {
 }
 
 #side-bar {
-  width: 200px;
+  flex: 0 0 200px;
   display: flex;
   flex-direction: column;
   background: #ddd;

--- a/Derelict/Game/src/styles.css
+++ b/Derelict/Game/src/styles.css
@@ -61,6 +61,7 @@ html, body {
   background: #111;
   color: #fff;
   overflow-x: auto;
+  overflow-y: auto;
   white-space: nowrap;
   font-family: monospace;
   padding: 4px;

--- a/Derelict/Game/src/styles.css
+++ b/Derelict/Game/src/styles.css
@@ -33,6 +33,13 @@ html, body {
   overflow: hidden;
 }
 
+#play-area {
+  display: flex;
+  flex-direction: column;
+  flex: none;
+  width: 2560px;
+}
+
 #viewport-wrap {
   position: relative;
   flex: none;
@@ -45,6 +52,17 @@ html, body {
   height: 100%;
   background: #000;
   display: block;
+}
+
+#log {
+  flex: none;
+  height: 80px;
+  background: #111;
+  color: #fff;
+  overflow-x: auto;
+  white-space: nowrap;
+  font-family: monospace;
+  padding: 4px;
 }
 
 #side-bar {

--- a/Derelict/Game/src/styles.css
+++ b/Derelict/Game/src/styles.css
@@ -36,15 +36,16 @@ html, body {
 #play-area {
   display: flex;
   flex-direction: column;
-  flex: none;
+  height: 100%;
   width: 2560px;
+  overflow: hidden;
 }
 
 #viewport-wrap {
   position: relative;
-  flex: none;
+  flex: 1 1 auto;
   width: 2560px;
-  height: 2560px;
+  overflow: hidden;
 }
 
 #viewport {

--- a/Derelict/Game/src/styles.css
+++ b/Derelict/Game/src/styles.css
@@ -30,14 +30,15 @@ html, body {
   flex: 1;
   display: flex;
   position: relative;
+  min-height: 0;
 }
 
 #play-area {
   flex: 1 1 0;
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
 
 #viewport-wrap {

--- a/Derelict/Players/src/index.ts
+++ b/Derelict/Players/src/index.ts
@@ -21,6 +21,7 @@ export interface Choice {
 export interface GameApi {
   choose(options: Choice[]): Promise<Choice>;
   messageBox(message: string): Promise<boolean>;
+  log?(message: string, color?: string): void;
 }
 
 // Basic player interface used by the rules engine
@@ -33,7 +34,7 @@ export class HumanPlayer implements Player {
   constructor(private game: GameApi) {}
 
   choose(options: Choice[]): Promise<Choice> {
-    console.log('Player choices', options);
+    this.game.log?.('Player choices requested');
     return this.game.choose(options);
   }
 }

--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -17,6 +17,7 @@ export class BasicRules implements Rules {
     private onChange?: (state: BoardState) => void,
     private onStatus?: (info: { turn: number; activePlayer: number; ap?: number }) => void,
     initialState?: { turn?: number; activePlayer?: number },
+    private onLog?: (message: string, color?: string) => void,
   ) {
     if (initialState) {
       if (typeof initialState.turn === 'number') this.turn = initialState.turn;
@@ -123,6 +124,7 @@ export class BasicRules implements Rules {
       }
     };
     this.emitStatus();
+    this.onLog?.(`Player ${this.activePlayer} begins turn ${this.turn}`);
     mainLoop: while (true) {
       const tokens = this.board.tokens.filter((t) =>
         currentSide === 'marine' ? isMarine(t) : t.type === 'alien' || isBlip(t),
@@ -360,6 +362,9 @@ export class BasicRules implements Rules {
                   apRemaining = initialAp(target);
                   lastMove = false;
                   this.emitStatus(apRemaining);
+                  this.onLog?.(
+                    `Player ${this.activePlayer} activated ${target.type} at (${choice.coord.x}, ${choice.coord.y})`,
+                  );
                 }
                 continue mainLoop;
               }
@@ -378,6 +383,7 @@ export class BasicRules implements Rules {
                 apRemaining = 0;
                 lastMove = false;
                 this.emitStatus();
+                this.onLog?.(`Player ${this.activePlayer} begins turn ${this.turn}`);
                 continue mainLoop;
               }
               break;
@@ -408,6 +414,9 @@ export class BasicRules implements Rules {
             apRemaining = initialAp(target);
             lastMove = false;
             this.emitStatus(apRemaining);
+            this.onLog?.(
+              `Player ${this.activePlayer} activated ${target.type} at (${target.cells[0].x}, ${target.cells[0].y})`,
+            );
           }
           break;
         }
@@ -444,6 +453,7 @@ export class BasicRules implements Rules {
           apRemaining = 0;
           lastMove = false;
           this.emitStatus();
+          this.onLog?.(`Player ${this.activePlayer} begins turn ${this.turn}`);
           break;
       }
     }


### PR DESCRIPTION
## Summary
- add scrollable log area beneath the game viewport
- expose log function so Rules and Players can record messages
- log turn starts and unit activations in basic rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c45eb2c5b483339ddbeb00c4f6fcc4