### PR TITLE
Implement assault action rules

### DIFF
--- a/Derelict/Game/src/index.ts
+++ b/Derelict/Game/src/index.ts
@@ -17,6 +17,7 @@ export interface ChooseUI {
   buttons: {
     activate: HTMLButtonElement;
     move: HTMLButtonElement;
+    assault: HTMLButtonElement;
     turnLeft: HTMLButtonElement;
     turnRight: HTMLButtonElement;
     manipulate: HTMLButtonElement;
@@ -57,6 +58,7 @@ export class Game implements GameApi {
       const { container, cellToRect, buttons } = this.ui!;
 
       buttons.move.textContent = "(M)ove";
+      buttons.assault.textContent = "(A)ssault";
       buttons.manipulate.textContent = "(E)manipulate";
       buttons.turnLeft.textContent = "Turn (L)eft";
       buttons.turnRight.textContent = "Turn (R)ight";
@@ -68,13 +70,19 @@ export class Game implements GameApi {
 
       const overlays: {
         el: HTMLElement;
-        type: "activate" | "move" | "door" | "turn" | "deploy";
+        type:
+          | "activate"
+          | "assault"
+          | "move"
+          | "door"
+          | "turn"
+          | "deploy";
       }[] = [];
 
       const addOverlay = (
         coord: Coord,
         color: string,
-        type: "activate" | "move" | "door" | "deploy",
+        type: "activate" | "assault" | "move" | "door" | "deploy",
         onClick?: () => void,
         apCost?: number,
       ) => {
@@ -87,8 +95,12 @@ export class Game implements GameApi {
         div.style.height = `${rect.height}px`;
         div.style.boxSizing = "border-box";
         div.style.border = `2px solid ${color}`;
-        const zMap: Record<"activate" | "move" | "door" | "deploy", number> = {
-          activate: 3,
+        const zMap: Record<
+          "activate" | "assault" | "move" | "door" | "deploy",
+          number
+        > = {
+          activate: 4,
+          assault: 3,
           move: 2,
           door: 1,
           deploy: 0,
@@ -109,6 +121,14 @@ export class Game implements GameApi {
           });
           div.addEventListener("mouseleave", () => {
             buttons.move.textContent = "(M)ove";
+          });
+        }
+        if (type === "assault" && typeof apCost === "number") {
+          div.addEventListener("mouseenter", () => {
+            buttons.assault.textContent = `(A)ssault: ${apCost} AP`;
+          });
+          div.addEventListener("mouseleave", () => {
+            buttons.assault.textContent = "(A)ssault";
           });
         }
         container.appendChild(div);
@@ -136,6 +156,22 @@ export class Game implements GameApi {
             opt.coord,
             "green",
             "move",
+            () => {
+              cleanup();
+              resolve(opt);
+            },
+            opt.apCost,
+          );
+        }
+        if (
+          opt.type === "action" &&
+          (opt.action as any) === "assault" &&
+          opt.coord
+        ) {
+          addOverlay(
+            opt.coord,
+            "red",
+            "assault",
             () => {
               cleanup();
               resolve(opt);
@@ -175,6 +211,13 @@ export class Game implements GameApi {
       if (doorOpt) {
         buttons.manipulate.textContent = `(E)manipulate: ${doorOpt.apCost ?? 0} AP`;
       }
+      const assaultOpt = options.find(
+        (o) => o.type === "action" && (o.action as any) === "assault",
+      );
+      if (assaultOpt) {
+        buttons.assault.textContent = `(A)ssault: ${assaultOpt.apCost ?? 0} AP`;
+        buttons.assault.style.color = assaultOpt.apCost === 0 ? "green" : "";
+      }
       const leftOpt = options.find(
         (o) => o.type === "action" && o.action === "turnLeft",
       );
@@ -190,8 +233,11 @@ export class Game implements GameApi {
         buttons.turnRight.style.color = rightOpt.apCost === 0 ? "green" : "";
       }
 
-      let filter: "activate" | "move" | "door" | "deploy" | null = null;
-      const setFilter = (f: "activate" | "move" | "door" | "deploy" | null) => {
+      let filter: "activate" | "assault" | "move" | "door" | "deploy" | null =
+        null;
+      const setFilter = (
+        f: "activate" | "assault" | "move" | "door" | "deploy" | null,
+      ) => {
         filter = f;
         for (const o of overlays) {
           o.el.style.display =
@@ -200,6 +246,7 @@ export class Game implements GameApi {
               : "none";
         }
         buttons.activate.classList.toggle("active", filter === "activate");
+        buttons.assault.classList.toggle("active", filter === "assault");
         buttons.move.classList.toggle("active", filter === "move");
         buttons.manipulate.classList.toggle("active", filter === "door");
         buttons.deploy.classList.toggle("active", filter === "deploy");
@@ -212,6 +259,10 @@ export class Game implements GameApi {
       function onMove() {
         if (buttons.move.disabled) return;
         setFilter(filter === "move" ? null : "move");
+      }
+      function onAssault() {
+        if (buttons.assault.disabled) return;
+        setFilter(filter === "assault" ? null : "assault");
       }
       function onManipulate() {
         if (buttons.manipulate.disabled) return;
@@ -284,6 +335,7 @@ export class Game implements GameApi {
         for (const o of overlays) o.el.remove();
         buttons.activate.removeEventListener("click", onActivate);
         buttons.move.removeEventListener("click", onMove);
+        buttons.assault.removeEventListener("click", onAssault);
         buttons.manipulate.removeEventListener("click", onManipulate);
         buttons.reveal.removeEventListener("click", onReveal);
         buttons.deploy.removeEventListener("click", onDeploy);
@@ -295,14 +347,17 @@ export class Game implements GameApi {
           document.removeEventListener("keydown", onKey);
         }
         buttons.activate.classList.remove("active");
+        buttons.assault.classList.remove("active");
         buttons.move.classList.remove("active");
         buttons.manipulate.classList.remove("active");
         buttons.deploy.classList.remove("active");
         buttons.guard.classList.remove("active");
         buttons.move.textContent = "(M)ove";
+        buttons.assault.textContent = "(A)ssault";
         buttons.manipulate.textContent = "(E)manipulate";
         buttons.turnLeft.textContent = "Turn (L)eft";
         buttons.turnRight.textContent = "Turn (R)ight";
+        buttons.assault.style.color = "";
         buttons.turnLeft.style.color = "";
         buttons.turnRight.style.color = "";
         this.cleanup = undefined;
@@ -311,6 +366,7 @@ export class Game implements GameApi {
 
       buttons.activate.addEventListener("click", onActivate);
       buttons.move.addEventListener("click", onMove);
+      buttons.assault.addEventListener("click", onAssault);
       buttons.manipulate.addEventListener("click", onManipulate);
       buttons.reveal.addEventListener("click", onReveal);
       buttons.deploy.addEventListener("click", onDeploy);
@@ -322,6 +378,7 @@ export class Game implements GameApi {
       const keyMap: Record<string, () => void> = {
         n: onActivate,
         m: onMove,
+        a: onAssault,
         e: onManipulate,
         v: onReveal,
         d: onDeploy,
@@ -347,6 +404,9 @@ export class Game implements GameApi {
       buttons.activate.disabled = !hasActivate;
       buttons.move.disabled = !options.some(
         (o) => o.type === "action" && o.action === "move",
+      );
+      buttons.assault.disabled = !options.some(
+        (o) => o.type === "action" && (o.action as any) === "assault",
       );
       buttons.manipulate.disabled = !options.some(
         (o) => o.type === "action" && o.action === "door",

--- a/Derelict/Game/src/index.ts
+++ b/Derelict/Game/src/index.ts
@@ -24,6 +24,8 @@ export interface ChooseUI {
     reveal: HTMLButtonElement;
     deploy: HTMLButtonElement;
     guard: HTMLButtonElement;
+    reroll: HTMLButtonElement;
+    accept: HTMLButtonElement;
     pass: HTMLButtonElement;
   };
 }
@@ -67,6 +69,8 @@ export class Game implements GameApi {
       buttons.reveal.textContent = "(V)reveal";
       buttons.deploy.textContent = "(D)eploy";
       buttons.guard.textContent = "(G)uard";
+      buttons.reroll.textContent = "Reroll (X)";
+      buttons.accept.textContent = "Accept (Y)";
 
       const overlays: {
         el: HTMLElement;
@@ -292,6 +296,26 @@ export class Game implements GameApi {
           resolve(opt);
         }
       }
+      function onReroll() {
+        if (buttons.reroll.disabled) return;
+        const opt = options.find(
+          (o) => o.type === "action" && (o.action as any) === "reroll",
+        );
+        if (opt) {
+          cleanup();
+          resolve(opt);
+        }
+      }
+      function onAccept() {
+        if (buttons.accept.disabled) return;
+        const opt = options.find(
+          (o) => o.type === "action" && (o.action as any) === "accept",
+        );
+        if (opt) {
+          cleanup();
+          resolve(opt);
+        }
+      }
       function onTurnLeft() {
         if (buttons.turnLeft.disabled) return;
         const opt = options.find(
@@ -340,6 +364,8 @@ export class Game implements GameApi {
         buttons.reveal.removeEventListener("click", onReveal);
         buttons.deploy.removeEventListener("click", onDeploy);
         buttons.guard.removeEventListener("click", onGuard);
+        buttons.reroll.removeEventListener("click", onReroll);
+        buttons.accept.removeEventListener("click", onAccept);
         buttons.turnLeft.removeEventListener("click", onTurnLeft);
         buttons.turnRight.removeEventListener("click", onTurnRight);
         buttons.pass.removeEventListener("click", onPass);
@@ -360,6 +386,8 @@ export class Game implements GameApi {
         buttons.assault.style.color = "";
         buttons.turnLeft.style.color = "";
         buttons.turnRight.style.color = "";
+        buttons.reroll.textContent = "Reroll (X)";
+        buttons.accept.textContent = "Accept (Y)";
         this.cleanup = undefined;
       };
       this.cleanup = cleanup;
@@ -371,6 +399,8 @@ export class Game implements GameApi {
       buttons.reveal.addEventListener("click", onReveal);
       buttons.deploy.addEventListener("click", onDeploy);
       buttons.guard.addEventListener("click", onGuard);
+       buttons.reroll.addEventListener("click", onReroll);
+       buttons.accept.addEventListener("click", onAccept);
       buttons.turnLeft.addEventListener("click", onTurnLeft);
       buttons.turnRight.addEventListener("click", onTurnRight);
       buttons.pass.addEventListener("click", onPass);
@@ -385,6 +415,8 @@ export class Game implements GameApi {
         g: onGuard,
         l: onTurnLeft,
         r: onTurnRight,
+        x: onReroll,
+        y: onAccept,
         p: onPass,
       };
       const onKey = (e: KeyboardEvent) => {
@@ -425,6 +457,12 @@ export class Game implements GameApi {
       );
       buttons.guard.disabled = !options.some(
         (o) => o.type === "action" && o.action === "guard",
+      );
+      buttons.reroll.disabled = !options.some(
+        (o) => o.type === "action" && (o.action as any) === "reroll",
+      );
+      buttons.accept.disabled = !options.some(
+        (o) => o.type === "action" && (o.action as any) === "accept",
       );
       buttons.pass.disabled = !options.some(
         (o) => o.type === "action" && o.action === "pass",

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -156,6 +156,14 @@ async function init() {
   btnGuard.textContent = "(G)uard";
   actionButtons.appendChild(btnGuard);
 
+  const btnReroll = document.createElement("button");
+  btnReroll.textContent = "Reroll (X)";
+  actionButtons.appendChild(btnReroll);
+
+  const btnAccept = document.createElement("button");
+  btnAccept.textContent = "Accept (Y)";
+  actionButtons.appendChild(btnAccept);
+
   const btnPass = document.createElement("button");
   btnPass.textContent = "(P)ass";
   actionButtons.appendChild(btnPass);
@@ -306,6 +314,8 @@ async function init() {
         reveal: btnReveal,
         deploy: btnDeploy,
         guard: btnGuard,
+        reroll: btnReroll,
+        accept: btnAccept,
         pass: btnPass,
       },
     }, logMessage);

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -136,6 +136,10 @@ async function init() {
   btnManipulate.textContent = "Manipulat(e)";
   actionButtons.appendChild(btnManipulate);
 
+  const btnAssault = document.createElement("button");
+  btnAssault.textContent = "(A)ssault";
+  actionButtons.appendChild(btnAssault);
+
   const btnActivate = document.createElement("button");
   btnActivate.textContent = "Activate Ally (N)";
   actionButtons.appendChild(btnActivate);
@@ -295,6 +299,7 @@ async function init() {
       buttons: {
         activate: btnActivate,
         move: btnMove,
+        assault: btnAssault,
         turnLeft: btnTurnLeft,
         turnRight: btnTurnRight,
         manipulate: btnManipulate,

--- a/Derelict/Game/tests/choose.test.js
+++ b/Derelict/Game/tests/choose.test.js
@@ -57,6 +57,7 @@ test('choose highlights activation options for different token types', async () 
     buttons: {
       activate: new DummyButton(),
       move: new DummyButton(),
+      assault: new DummyButton(),
       turnLeft: new DummyButton(),
       turnRight: new DummyButton(),
       manipulate: new DummyButton(),
@@ -130,6 +131,7 @@ test('move option takes precedence over door option on same cell', async () => {
     buttons: {
       activate: new DummyButton(),
       move: new DummyButton(),
+      assault: new DummyButton(),
       turnLeft: new DummyButton(),
       turnRight: new DummyButton(),
       manipulate: new DummyButton(),
@@ -156,6 +158,90 @@ test('move option takes precedence over door option on same cell', async () => {
   moveOverlay.listeners.click({ stopPropagation() {} });
   const result = await promise;
   assert.deepEqual(result, moveOpt);
+
+  globalThis.document = origDoc;
+});
+
+test('assault option takes precedence over move option on same cell', async () => {
+  const board = { size: 1, segments: [], tokens: [] };
+  const renderer = { render() {} };
+  const rules = { validate() {}, runGame: async () => {} };
+  const player = { choose: async () => ({ type: 'action', action: 'pass' }) };
+
+  class DummyElement {
+    constructor() {
+      this.style = {};
+      this.children = [];
+      this.listeners = {};
+      this.classList = { toggle() {}, remove() {}, add() {} };
+    }
+    appendChild(el) {
+      this.children.push(el);
+    }
+    addEventListener(name, fn) {
+      this.listeners[name] = fn;
+    }
+    removeEventListener(name) {
+      delete this.listeners[name];
+    }
+    remove() {}
+  }
+  class DummyButton extends DummyElement {
+    constructor() {
+      super();
+      this.disabled = false;
+    }
+  }
+
+  const created = [];
+  const origDoc = globalThis.document;
+  globalThis.document = {
+    createElement: () => {
+      const el = new DummyElement();
+      created.push(el);
+      return el;
+    },
+  };
+
+  const ui = {
+    container: new DummyElement(),
+    cellToRect: () => ({ x: 0, y: 0, width: 1, height: 1 }),
+    buttons: {
+      activate: new DummyButton(),
+      move: new DummyButton(),
+      assault: new DummyButton(),
+      turnLeft: new DummyButton(),
+      turnRight: new DummyButton(),
+      manipulate: new DummyButton(),
+      reveal: new DummyButton(),
+      deploy: new DummyButton(),
+      guard: new DummyButton(),
+      pass: new DummyButton(),
+    },
+  };
+
+  const game = new Game(board, renderer, rules, player, player, ui);
+  const assaultOpt = { type: 'action', action: 'assault', coord: { x: 0, y: 0 } };
+  const moveOpt = { type: 'action', action: 'move', coord: { x: 0, y: 0 } };
+  const options = [moveOpt, assaultOpt];
+
+  const promise = game.choose(options);
+  assert.equal(created.length, 2);
+
+  const assaultOverlay = created.find(
+    (e) => e.style.border === '2px solid red'
+  );
+  const moveOverlay = created.find(
+    (e) => e.style.border === '2px solid green'
+  );
+  assert.ok(assaultOverlay && moveOverlay);
+  assert.ok(
+    Number(assaultOverlay.style.zIndex) > Number(moveOverlay.style.zIndex)
+  );
+
+  assaultOverlay.listeners.click({ stopPropagation() {} });
+  const result = await promise;
+  assert.deepEqual(result, assaultOpt);
 
   globalThis.document = origDoc;
 });

--- a/Derelict/Game/tests/choose.test.js
+++ b/Derelict/Game/tests/choose.test.js
@@ -64,6 +64,8 @@ test('choose highlights activation options for different token types', async () 
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      reroll: new DummyButton(),
+      accept: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -138,6 +140,8 @@ test('move option takes precedence over door option on same cell', async () => {
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      reroll: new DummyButton(),
+      accept: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -216,6 +220,8 @@ test('assault option takes precedence over move option on same cell', async () =
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      reroll: new DummyButton(),
+      accept: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -242,6 +248,75 @@ test('assault option takes precedence over move option on same cell', async () =
   assaultOverlay.listeners.click({ stopPropagation() {} });
   const result = await promise;
   assert.deepEqual(result, assaultOpt);
+
+  globalThis.document = origDoc;
+});
+
+test('reroll and accept buttons resolve options', async () => {
+  const board = { size: 1, segments: [], tokens: [] };
+  const renderer = { render() {} };
+  const rules = { validate() {}, runGame: async () => {} };
+  const player = { choose: async () => ({ type: 'action', action: 'pass' }) };
+
+  class DummyElement {
+    constructor() {
+      this.style = {};
+      this.children = [];
+      this.listeners = {};
+      this.classList = { toggle() {}, remove() {}, add() {} };
+    }
+    appendChild(el) {
+      this.children.push(el);
+    }
+    addEventListener(name, fn) {
+      this.listeners[name] = fn;
+    }
+    removeEventListener(name) {
+      delete this.listeners[name];
+    }
+    remove() {}
+  }
+  class DummyButton extends DummyElement {
+    constructor() {
+      super();
+      this.disabled = false;
+    }
+  }
+
+  const origDoc = globalThis.document;
+  globalThis.document = { createElement: () => new DummyElement() };
+
+  const ui = {
+    container: new DummyElement(),
+    cellToRect: () => ({ x: 0, y: 0, width: 1, height: 1 }),
+    buttons: {
+      activate: new DummyButton(),
+      move: new DummyButton(),
+      assault: new DummyButton(),
+      turnLeft: new DummyButton(),
+      turnRight: new DummyButton(),
+      manipulate: new DummyButton(),
+      reveal: new DummyButton(),
+      deploy: new DummyButton(),
+      guard: new DummyButton(),
+      reroll: new DummyButton(),
+      accept: new DummyButton(),
+      pass: new DummyButton(),
+    },
+  };
+
+  const game = new Game(board, renderer, rules, player, player, ui);
+  const rerollOpt = { type: 'action', action: 'reroll' };
+  const acceptOpt = { type: 'action', action: 'accept' };
+  const options = [rerollOpt, acceptOpt];
+
+  const promise = game.choose(options);
+  assert.equal(ui.buttons.reroll.disabled, false);
+  assert.equal(ui.buttons.accept.disabled, false);
+
+  ui.buttons.reroll.listeners.click({});
+  const result = await promise;
+  assert.deepEqual(result, rerollOpt);
 
   globalThis.document = origDoc;
 });

--- a/Derelict/Game/tests/dispose.test.js
+++ b/Derelict/Game/tests/dispose.test.js
@@ -62,6 +62,8 @@ test("dispose clears overlays and listeners", () => {
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      reroll: new DummyButton(),
+      accept: new DummyButton(),
       pass: new DummyButton(),
     },
   };

--- a/Derelict/Game/tests/dispose.test.js
+++ b/Derelict/Game/tests/dispose.test.js
@@ -55,6 +55,7 @@ test("dispose clears overlays and listeners", () => {
     buttons: {
       activate: new DummyButton(),
       move: new DummyButton(),
+      assault: new DummyButton(),
       turnLeft: new DummyButton(),
       turnRight: new DummyButton(),
       manipulate: new DummyButton(),

--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -193,6 +193,30 @@ export class BasicRules implements Rules {
             }
           }
         }
+        const front = forwardCell(active.cells[0], active.rot as Rotation);
+        const targetToken = this.board.tokens.find((t) =>
+          t.cells.some((c) => sameCoord(c, front)),
+        );
+        if (
+          targetToken &&
+          apRemaining >= 1 &&
+          ((isMarine(active) &&
+            (targetToken.type === 'alien' ||
+              targetToken.type === 'door' ||
+              targetToken.type === 'dooropen')) ||
+            (active.type === 'alien' &&
+              (isMarine(targetToken) ||
+                targetToken.type === 'door' ||
+                targetToken.type === 'dooropen')))
+        ) {
+          actionChoices.push({
+            type: 'action',
+            action: 'assault' as any,
+            coord: front,
+            apCost: 1,
+            apRemaining,
+          });
+        }
         const tCost = getTurnCost(active, lastMove);
         if (apRemaining >= tCost) {
           actionChoices.push({
@@ -254,7 +278,8 @@ export class BasicRules implements Rules {
       }
 
       const action = await currentPlayer.choose(actionChoices);
-      switch (action.action) {
+      const actionType = action.action as string;
+      switch (actionType) {
         case 'move':
           if (active && action.coord && typeof action.apCost === 'number') {
             moveToken(active, action.coord);
@@ -283,6 +308,187 @@ export class BasicRules implements Rules {
             this.onChange?.(this.board);
             await checkInvoluntaryReveals();
             this.emitStatus(apRemaining);
+          }
+          break;
+        case 'assault':
+          if (active && action.coord && typeof action.apCost === 'number') {
+            const target = this.board.tokens.find((t) =>
+              t.cells.some((c) => sameCoord(c, action.coord!)),
+            );
+            if (target) {
+              apRemaining -= action.apCost;
+              lastMove = false;
+              if (target.type === 'door' || target.type === 'dooropen') {
+                if (isMarine(active) && active.type === 'marine_chain') {
+                  removeToken(this.board, target);
+                } else {
+                  const rolls = rollDice(baseDice(active.type));
+                  if (rolls.some((r) => r === 6)) {
+                    removeToken(this.board, target);
+                  }
+                }
+                this.onChange?.(this.board);
+                await checkInvoluntaryReveals();
+                this.emitStatus(apRemaining);
+              } else if (
+                (isMarine(active) && target.type === 'alien') ||
+                (active.type === 'alien' && isMarine(target))
+              ) {
+                const attackerPlayer = currentPlayer;
+                const defenderPlayer = currentPlayer === p1 ? p2 : p1;
+                let marine: TokenInstance;
+                let alien: TokenInstance;
+                let marinePlayer: Player;
+                const marineIsAttacker = isMarine(active);
+                if (marineIsAttacker) {
+                  marine = active;
+                  alien = target;
+                  marinePlayer = attackerPlayer;
+                } else {
+                  marine = target;
+                  alien = active;
+                  marinePlayer = defenderPlayer;
+                }
+                const marineFacing = sameCoord(
+                  forwardCell(marine.cells[0], marine.rot as Rotation),
+                  alien.cells[0],
+                );
+                let marineDice = baseDice(marine.type);
+                let alienDice = baseDice(alien.type);
+                if (marineFacing) {
+                  if (marine.type === 'marine_hammer') alienDice--;
+                  if (marine.type === 'marine_claws') marineDice++;
+                }
+                if (alienDice < 0) alienDice = 0;
+                if (marineDice < 0) marineDice = 0;
+                let marineRolls = rollDice(marineDice);
+                let alienRolls = rollDice(alienDice);
+                if (marineFacing) {
+                  if (marine.type === 'marine_hammer')
+                    marineRolls = marineRolls.map((r) => r + 2);
+                  if (marine.type === 'marine_claws')
+                    marineRolls = marineRolls.map((r) => r + 1);
+                  if (marine.type === 'marine_sarge')
+                    marineRolls = marineRolls.map((r) => r + 1);
+                }
+                let attackerRolls = marineIsAttacker ? marineRolls : alienRolls;
+                let defenderRolls = marineIsAttacker ? alienRolls : marineRolls;
+                const evaluate = () => {
+                  const maxA = attackerRolls.length
+                    ? Math.max(...attackerRolls)
+                    : 0;
+                  const maxD = defenderRolls.length
+                    ? Math.max(...defenderRolls)
+                    : 0;
+                  if (maxA > maxD) return 'attacker';
+                  if (maxD > maxA) return 'defender';
+                  return 'tie';
+                };
+                let outcome = evaluate();
+                const marineHasGuard = this.board.tokens.some(
+                  (t) =>
+                    t.type === 'guard' &&
+                    t.cells.some((c) => sameCoord(c, marine.cells[0])),
+                );
+                const marineWon = () =>
+                  (marineIsAttacker && outcome === 'attacker') ||
+                  (!marineIsAttacker && outcome === 'defender');
+                if (
+                  marineFacing &&
+                  marine.type === 'marine_sarge' &&
+                  !marineWon()
+                ) {
+                  const choice = await marinePlayer.choose([
+                    { type: 'action', action: 'reroll' as any, apCost: 0, apRemaining },
+                    { type: 'action', action: 'accept' as any, apCost: 0, apRemaining },
+                  ]);
+                  const cAct = choice.action as string;
+                  if (cAct === 'reroll' && alienRolls.length > 0) {
+                    alienRolls.sort((a, b) => b - a);
+                    alienRolls[0] = rollDice(1)[0];
+                    alienRolls.sort((a, b) => b - a);
+                    attackerRolls = marineIsAttacker
+                      ? marineRolls
+                      : alienRolls;
+                    defenderRolls = marineIsAttacker
+                      ? alienRolls
+                      : marineRolls;
+                    outcome = evaluate();
+                  }
+                }
+                if (marineFacing && marineHasGuard && !marineWon()) {
+                  const choice = await marinePlayer.choose([
+                    { type: 'action', action: 'reroll' as any, apCost: 0, apRemaining },
+                    { type: 'action', action: 'accept' as any, apCost: 0, apRemaining },
+                  ]);
+                  const cAct2 = choice.action as string;
+                  if (cAct2 === 'reroll') {
+                    marineRolls = rollDice(marineDice);
+                    if (marineFacing) {
+                      if (marine.type === 'marine_hammer')
+                        marineRolls = marineRolls.map((r) => r + 2);
+                      if (marine.type === 'marine_claws')
+                        marineRolls = marineRolls.map((r) => r + 1);
+                      if (marine.type === 'marine_sarge')
+                        marineRolls = marineRolls.map((r) => r + 1);
+                    }
+                    attackerRolls = marineIsAttacker
+                      ? marineRolls
+                      : alienRolls;
+                    defenderRolls = marineIsAttacker
+                      ? alienRolls
+                      : marineRolls;
+                    outcome = evaluate();
+                  }
+                }
+                if (outcome === 'attacker') {
+                  removeToken(this.board, target);
+                  this.onChange?.(this.board);
+                  await checkInvoluntaryReveals();
+                } else if (outcome === 'defender') {
+                  const defFacing = sameCoord(
+                    forwardCell(target.cells[0], target.rot as Rotation),
+                    active.cells[0],
+                  );
+                  if (defFacing) {
+                    removeToken(this.board, active);
+                    active = null;
+                    apRemaining = 0;
+                    this.onChange?.(this.board);
+                    await checkInvoluntaryReveals();
+                  } else {
+                    const choice = await defenderPlayer.choose([
+                      { type: 'action', action: 'turn' as any, apCost: 0, apRemaining },
+                      { type: 'action', action: 'accept' as any, apCost: 0, apRemaining },
+                    ]);
+                    const dAct = choice.action as string;
+                    if (dAct === 'turn') {
+                      target.rot = rotationTowards(target.cells[0], active.cells[0]);
+                      this.onChange?.(this.board);
+                      await checkInvoluntaryReveals();
+                    }
+                  }
+                } else {
+                  const defFacing = sameCoord(
+                    forwardCell(target.cells[0], target.rot as Rotation),
+                    active.cells[0],
+                  );
+                  if (!defFacing) {
+                    const choice = await defenderPlayer.choose([
+                      { type: 'action', action: 'turn' as any, apCost: 0, apRemaining },
+                      { type: 'action', action: 'accept' as any, apCost: 0, apRemaining },
+                    ]);
+                    const dAct2 = choice.action as string;
+                    if (dAct2 === 'turn') {
+                      target.rot = rotationTowards(target.cells[0], active.cells[0]);
+                      this.onChange?.(this.board);
+                      await checkInvoluntaryReveals();
+                    }
+                  }
+                }
+                this.emitStatus(apRemaining);
+              }
+            }
           }
           break;
         case 'guard':
@@ -733,6 +939,39 @@ function hasDeactivatedToken(board: BoardState, coord: Coord): boolean {
   return board.tokens.some(
     (t) => t.type === 'deactivated' && t.cells.some((c) => sameCoord(c, coord)),
   );
+}
+
+function removeToken(board: BoardState, token: TokenInstance) {
+  const coord = token.cells[0];
+  board.tokens = board.tokens.filter(
+    (t) =>
+      t !== token &&
+      !(t.cells.some((c) => sameCoord(c, coord)) &&
+        (t.type === 'guard' || t.type === 'overwatch' || t.type === 'jam')),
+  );
+}
+
+function baseDice(type: string): number {
+  if (type === 'alien') return 3;
+  if (type === 'door' || type === 'dooropen') return 0;
+  if (type.startsWith('marine')) return 1;
+  return 0;
+}
+
+function rollDice(n: number): number[] {
+  const res: number[] = [];
+  for (let i = 0; i < n; i++) {
+    res.push(Math.floor(Math.random() * 6) + 1);
+  }
+  return res.sort((a, b) => b - a);
+}
+
+function rotationTowards(from: Coord, to: Coord): Rotation {
+  if (to.x === from.x && to.y === from.y + 1) return 0;
+  if (to.x === from.x - 1 && to.y === from.y) return 90;
+  if (to.x === from.x && to.y === from.y - 1) return 180;
+  if (to.x === from.x + 1 && to.y === from.y) return 270;
+  return 0;
 }
 
 function hasLineOfSightOneWay(

--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -875,3 +875,78 @@ test('guard action ends activation and clears on next marine turn', async () => 
   assert.equal(hadGuard, true);
   assert.equal(guardCleared, true);
 });
+
+test('assault action offered and removes alien on win', async () => {
+  const board = {
+    size: 5,
+    segments: [],
+    tokens: [
+      { instanceId: 'M1', type: 'marine', rot: 0, cells: [{ x: 0, y: 0 }] },
+      { instanceId: 'A1', type: 'alien', rot: 0, cells: [{ x: 0, y: 1 }] },
+    ],
+  };
+  const rules = new BasicRules(board);
+  rules.validate(board);
+
+  let calls = 0;
+  let secondOpts;
+  let tokensAfter;
+  const originalRandom = Math.random;
+  const seq = [0.9, 0.1, 0.1, 0.1];
+  Math.random = () => seq.shift() || 0;
+  const player = {
+    choose: async (options) => {
+      calls++;
+      if (calls === 1) return options.find((o) => o.action === 'activate');
+      if (calls === 2) {
+        secondOpts = options;
+        return options.find((o) => o.action === 'assault');
+      }
+      if (calls === 3) {
+        tokensAfter = board.tokens.map((t) => t.type);
+        board.tokens = [];
+        return options[0];
+      }
+      return options[0];
+    },
+  };
+
+  await rules.runGame(player, player);
+  Math.random = originalRandom;
+
+  assert.ok(secondOpts.some((o) => o.action === 'assault'));
+  assert.ok(!tokensAfter.includes('alien'));
+});
+
+test('marine_chain assault destroys door', async () => {
+  const board = {
+    size: 5,
+    segments: [],
+    tokens: [
+      { instanceId: 'M1', type: 'marine_chain', rot: 0, cells: [{ x: 0, y: 0 }] },
+      { instanceId: 'D1', type: 'door', rot: 0, cells: [{ x: 0, y: 1 }] },
+    ],
+  };
+  const rules = new BasicRules(board);
+  rules.validate(board);
+
+  let calls = 0;
+  let doorPresent;
+  const player = {
+    choose: async (options) => {
+      calls++;
+      if (calls === 1) return options.find((o) => o.action === 'activate');
+      if (calls === 2) return options.find((o) => o.action === 'assault');
+      if (calls === 3) {
+        doorPresent = board.tokens.some((t) => t.instanceId === 'D1');
+        board.tokens = [];
+        return options[0];
+      }
+      return options[0];
+    },
+  };
+
+  await rules.runGame(player, player);
+
+  assert.equal(doorPresent, false);
+});


### PR DESCRIPTION
## Summary
- add assault action offering when facing enemies or doors
- handle assault resolution with dice, special marine abilities, and reroll options
- test assault behavior and marine_chain door destruction

## Testing
- `cd Rules && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c56a137d3c8333a124abf222581643