### PR TITLE
feat: use modal for binary choices

### DIFF
--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -155,15 +155,6 @@ async function init() {
   const btnGuard = document.createElement("button");
   btnGuard.textContent = "(G)uard";
   actionButtons.appendChild(btnGuard);
-
-  const btnReroll = document.createElement("button");
-  btnReroll.textContent = "Reroll (X)";
-  actionButtons.appendChild(btnReroll);
-
-  const btnAccept = document.createElement("button");
-  btnAccept.textContent = "Accept (Y)";
-  actionButtons.appendChild(btnAccept);
-
   const btnPass = document.createElement("button");
   btnPass.textContent = "(P)ass";
   actionButtons.appendChild(btnPass);
@@ -344,8 +335,6 @@ async function init() {
         reveal: btnReveal,
         deploy: btnDeploy,
         guard: btnGuard,
-        reroll: btnReroll,
-        accept: btnAccept,
         pass: btnPass,
       },
     }, logMessage);

--- a/Derelict/Game/tests/choose.test.js
+++ b/Derelict/Game/tests/choose.test.js
@@ -64,8 +64,6 @@ test('choose highlights activation options for different token types', async () 
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
-      reroll: new DummyButton(),
-      accept: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -140,8 +138,6 @@ test('move option takes precedence over door option on same cell', async () => {
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
-      reroll: new DummyButton(),
-      accept: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -220,8 +216,6 @@ test('assault option takes precedence over move option on same cell', async () =
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
-      reroll: new DummyButton(),
-      accept: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -252,7 +246,7 @@ test('assault option takes precedence over move option on same cell', async () =
   globalThis.document = origDoc;
 });
 
-test('reroll and accept buttons resolve options', async () => {
+test('binary action choice uses modal dialog', async () => {
   const board = { size: 1, segments: [], tokens: [] };
   const renderer = { render() {} };
   const rules = { validate() {}, runGame: async () => {} };
@@ -283,8 +277,12 @@ test('reroll and accept buttons resolve options', async () => {
     }
   }
 
+  const body = new DummyElement();
   const origDoc = globalThis.document;
-  globalThis.document = { createElement: () => new DummyElement() };
+  globalThis.document = {
+    createElement: () => new DummyElement(),
+    body,
+  };
 
   const ui = {
     container: new DummyElement(),
@@ -299,8 +297,6 @@ test('reroll and accept buttons resolve options', async () => {
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
-      reroll: new DummyButton(),
-      accept: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -311,10 +307,12 @@ test('reroll and accept buttons resolve options', async () => {
   const options = [rerollOpt, acceptOpt];
 
   const promise = game.choose(options);
-  assert.equal(ui.buttons.reroll.disabled, false);
-  assert.equal(ui.buttons.accept.disabled, false);
-
-  ui.buttons.reroll.listeners.click({});
+  assert.equal(body.children.length, 1);
+  const overlay = body.children[0];
+  const dlg = overlay.children[0];
+  const actions = dlg.children[1];
+  const btn = actions.children[0];
+  btn.listeners.click({});
   const result = await promise;
   assert.deepEqual(result, rerollOpt);
 


### PR DESCRIPTION
## Summary
- handle reroll/accept/turn via modal dialog
- drop Reroll and Accept buttons from game UI
- cover modal behaviour in choose tests

## Testing
- `npm run build` (Renderer)
- `npm run build` (BoardState)
- `npm run build` (Rules)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e42653608333918e6c7b36f00caf