### PR TITLE
Expand log area height in game page

### DIFF
--- a/Derelict/Game/src/styles.css
+++ b/Derelict/Game/src/styles.css
@@ -57,7 +57,7 @@ html, body {
 }
 
 #log {
-  flex: 0 0 80px;
+  flex: 0 0 160px;
   background: #111;
   color: #fff;
   overflow-x: auto;


### PR DESCRIPTION
## Summary
- double the height of the game log area to display more entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f0bb8c4c833395150936b082133e