### PR TITLE
Prioritize move options over assaults in Game UI

### DIFF
--- a/Derelict/Game/docs/SRD.md
+++ b/Derelict/Game/docs/SRD.md
@@ -98,8 +98,8 @@ A keyboard key accelerator listed in the Key column has the same effect as click
 | activate CELL | activate 	 | n	 | available ally  | purple          | |
 | shoot CELL    | shoot  	 | s	 | visible enemy   | orange          | all visible cells when button clicked; ap cost might be free; ammo availability for flamer; may disable on jam; button may name after weapon |
 | move CELL     | move	     | m	 | legal move cell | green           | marines: fw+back, aliens and blips all 4 dirs. aliens and blips move ap might be free after turn action |
-| assault CELL  | assault    | a	 | adjacent enemy  | red             | |
 | door CELL     | manipulate | e	 | adjacent door   | blue            | |	
+| assault CELL  | assault    | a	 | adjacent enemy  | red             | |
 | turn left	    | turn left  | l	 | none	           | none            | ap cost might be 0 after move action |
 | turn right    | turn right | r	 | none	           | none            | ap cost might be 0 after move action |
 | unjam         | clear jam	 | u	 | none		       | none            | on jam token; this could be rename of shoot button rather than distinct weapon |

--- a/Derelict/Game/src/index.ts
+++ b/Derelict/Game/src/index.ts
@@ -144,8 +144,8 @@ export class Game implements GameApi {
           number
         > = {
           activate: 4,
-          assault: 3,
-          move: 2,
+          move: 3,
+          assault: 2,
           door: 1,
           deploy: 0,
         };

--- a/Derelict/Game/src/index.ts
+++ b/Derelict/Game/src/index.ts
@@ -145,8 +145,8 @@ export class Game implements GameApi {
         > = {
           activate: 4,
           move: 3,
-          assault: 2,
-          door: 1,
+          door: 2,
+          assault: 1,
           deploy: 0,
         };
         div.style.zIndex = String(zMap[type]);

--- a/Derelict/Game/tests/choose.test.js
+++ b/Derelict/Game/tests/choose.test.js
@@ -250,6 +250,88 @@ test('move option takes precedence over assault option on same cell', async () =
   globalThis.document = origDoc;
 });
 
+test('door option takes precedence over assault option on same cell', async () => {
+  const board = { size: 1, segments: [], tokens: [] };
+  const renderer = { render() {} };
+  const rules = { validate() {}, runGame: async () => {} };
+  const player = { choose: async () => ({ type: 'action', action: 'pass' }) };
+
+  class DummyElement {
+    constructor() {
+      this.style = {};
+      this.children = [];
+      this.listeners = {};
+      this.classList = { toggle() {}, remove() {}, add() {} };
+    }
+    appendChild(el) {
+      this.children.push(el);
+    }
+    addEventListener(name, fn) {
+      this.listeners[name] = fn;
+    }
+    removeEventListener(name) {
+      delete this.listeners[name];
+    }
+    remove() {}
+  }
+  class DummyButton extends DummyElement {
+    constructor() {
+      super();
+      this.disabled = false;
+    }
+  }
+
+  const created = [];
+  const origDoc = globalThis.document;
+  globalThis.document = {
+    createElement: () => {
+      const el = new DummyElement();
+      created.push(el);
+      return el;
+    },
+  };
+
+  const ui = {
+    container: new DummyElement(),
+    cellToRect: () => ({ x: 0, y: 0, width: 1, height: 1 }),
+    buttons: {
+      activate: new DummyButton(),
+      move: new DummyButton(),
+      assault: new DummyButton(),
+      turnLeft: new DummyButton(),
+      turnRight: new DummyButton(),
+      manipulate: new DummyButton(),
+      reveal: new DummyButton(),
+      deploy: new DummyButton(),
+      guard: new DummyButton(),
+      pass: new DummyButton(),
+    },
+  };
+
+  const game = new Game(board, renderer, rules, player, player, ui);
+  const doorOpt = { type: 'action', action: 'door', coord: { x: 0, y: 0 } };
+  const assaultOpt = {
+    type: 'action',
+    action: 'assault',
+    coord: { x: 0, y: 0 },
+  };
+  const options = [assaultOpt, doorOpt];
+
+  const promise = game.choose(options);
+  assert.equal(created.length, 2);
+
+  const doorOverlay = created.find((e) => e.style.border === '2px solid blue');
+  const assaultOverlay = created.find((e) => e.style.border === '2px solid red');
+  assert.ok(doorOverlay && assaultOverlay);
+  assert.ok(Number(doorOverlay.style.zIndex) > Number(assaultOverlay.style.zIndex));
+
+  doorOverlay.listeners.click({ stopPropagation() {} });
+  const result = await promise;
+  assert.deepEqual(result, doorOpt);
+
+  globalThis.document = origDoc;
+});
+
 test('binary action choice uses modal dialog', async () => {
   const board = { size: 1, segments: [], tokens: [] };
   const renderer = { render() {} };

--- a/Derelict/Game/tests/choose.test.js
+++ b/Derelict/Game/tests/choose.test.js
@@ -162,7 +162,7 @@ test('move option takes precedence over door option on same cell', async () => {
   globalThis.document = origDoc;
 });
 
-test('assault option takes precedence over move option on same cell', async () => {
+test('move option takes precedence over assault option on same cell', async () => {
   const board = { size: 1, segments: [], tokens: [] };
   const renderer = { render() {} };
   const rules = { validate() {}, runGame: async () => {} };
@@ -221,7 +221,11 @@ test('assault option takes precedence over move option on same cell', async () =
   };
 
   const game = new Game(board, renderer, rules, player, player, ui);
-  const assaultOpt = { type: 'action', action: 'assault', coord: { x: 0, y: 0 } };
+  const assaultOpt = {
+    type: 'action',
+    action: 'assault',
+    coord: { x: 0, y: 0 },
+  };
   const moveOpt = { type: 'action', action: 'move', coord: { x: 0, y: 0 } };
   const options = [moveOpt, assaultOpt];
 
@@ -236,12 +240,12 @@ test('assault option takes precedence over move option on same cell', async () =
   );
   assert.ok(assaultOverlay && moveOverlay);
   assert.ok(
-    Number(assaultOverlay.style.zIndex) > Number(moveOverlay.style.zIndex)
+    Number(moveOverlay.style.zIndex) > Number(assaultOverlay.style.zIndex)
   );
 
-  assaultOverlay.listeners.click({ stopPropagation() {} });
+  moveOverlay.listeners.click({ stopPropagation() {} });
   const result = await promise;
-  assert.deepEqual(result, assaultOpt);
+  assert.deepEqual(result, moveOpt);
 
   globalThis.document = origDoc;
 });


### PR DESCRIPTION
## Summary
- Ensure move cell overlays have higher priority than assault overlays
- Update Game choose tests to check move takes precedence over assault

## Testing
- `npm run lint --workspace Game`
- `npm run build`
- `npm test --workspace Game`


------
https://chatgpt.com/codex/tasks/task_e_68c716e672a48333b15015dac512e5ec