### PR TITLE
Implement command point mechanics and command action

### DIFF
--- a/Derelict/Game/src/index.ts
+++ b/Derelict/Game/src/index.ts
@@ -26,6 +26,7 @@ export interface ChooseUI {
     reveal: HTMLButtonElement;
     deploy: HTMLButtonElement;
     guard: HTMLButtonElement;
+    command: HTMLButtonElement;
     pass: HTMLButtonElement;
   };
 }
@@ -116,6 +117,7 @@ export class Game implements GameApi {
       buttons.reveal.textContent = "(V)reveal";
       buttons.deploy.textContent = "(D)eploy";
       buttons.guard.textContent = "(G)uard";
+      buttons.command.textContent = "(C)ommand";
       buttons.overwatch.style.color = "";
 
       let shootLabel = "(S)hoot";
@@ -315,6 +317,15 @@ export class Game implements GameApi {
         buttons.overwatch.textContent = "(O)verwatch";
         buttons.overwatch.style.color = "";
       }
+      const commandOpt = options.find(
+        (o) => o.type === "action" && o.action === "command",
+      );
+      if (commandOpt) {
+        const cp = commandOpt.commandPointsRemaining ?? 0;
+        buttons.command.textContent = `(C)ommand: ${cp} CP`;
+      } else {
+        buttons.command.textContent = "(C)ommand";
+      }
       const leftOpt = options.find(
         (o) => o.type === "action" && o.action === "turnLeft",
       );
@@ -439,6 +450,17 @@ export class Game implements GameApi {
         }
       }
 
+      function onCommand() {
+        if (buttons.command.disabled) return;
+        const opt = options.find(
+          (o) => o.type === "action" && o.action === "command",
+        );
+        if (opt) {
+          cleanup();
+          resolve(opt);
+        }
+      }
+
       function onPass() {
         if (buttons.pass.disabled) return;
         const opt = options.find(
@@ -470,6 +492,7 @@ export class Game implements GameApi {
         buttons.overwatch.removeEventListener("click", onOverwatch);
         buttons.turnLeft.removeEventListener("click", onTurnLeft);
         buttons.turnRight.removeEventListener("click", onTurnRight);
+        buttons.command.removeEventListener("click", onCommand);
         buttons.pass.removeEventListener("click", onPass);
         if (document.removeEventListener) {
           document.removeEventListener("keydown", onKey);
@@ -493,6 +516,7 @@ export class Game implements GameApi {
         buttons.turnRight.style.color = "";
         buttons.overwatch.textContent = "(O)verwatch";
         buttons.overwatch.style.color = "";
+        buttons.command.textContent = "(C)ommand";
         this.cleanup = undefined;
       };
       this.cleanup = cleanup;
@@ -508,6 +532,7 @@ export class Game implements GameApi {
       buttons.overwatch.addEventListener("click", onOverwatch);
       buttons.turnLeft.addEventListener("click", onTurnLeft);
       buttons.turnRight.addEventListener("click", onTurnRight);
+      buttons.command.addEventListener("click", onCommand);
       buttons.pass.addEventListener("click", onPass);
 
       const keyMap: Record<string, () => void> = {
@@ -522,6 +547,7 @@ export class Game implements GameApi {
         o: onOverwatch,
         l: onTurnLeft,
         r: onTurnRight,
+        c: onCommand,
         p: onPass,
       };
       const onKey = (e: KeyboardEvent) => {
@@ -568,6 +594,9 @@ export class Game implements GameApi {
       );
       buttons.overwatch.disabled = !options.some(
         (o) => o.type === "action" && o.action === "overwatch",
+      );
+      buttons.command.disabled = !options.some(
+        (o) => o.type === "action" && o.action === "command",
       );
       buttons.pass.disabled = !options.some(
         (o) => o.type === "action" && o.action === "pass",

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -163,6 +163,9 @@ async function init() {
   const btnGuard = document.createElement("button");
   btnGuard.textContent = "(G)uard";
   actionButtons.appendChild(btnGuard);
+  const btnCommand = document.createElement("button");
+  btnCommand.textContent = "(C)ommand";
+  actionButtons.appendChild(btnCommand);
   const btnPass = document.createElement("button");
   btnPass.textContent = "(P)ass";
   actionButtons.appendChild(btnPass);
@@ -172,9 +175,11 @@ async function init() {
   const statusTurn = document.createElement("div");
   const statusPlayer = document.createElement("div");
   const statusAP = document.createElement("div");
+  const statusCommand = document.createElement("div");
   status.appendChild(statusTurn);
   status.appendChild(statusPlayer);
   status.appendChild(statusAP);
+  status.appendChild(statusCommand);
   side.appendChild(status);
 
   const ctx = canvas.getContext("2d");
@@ -253,6 +258,7 @@ async function init() {
     turn: number;
     activePlayer: number;
     ap?: number;
+    commandPoints?: number;
   }) => {
     statusTurn.textContent = `Turn: ${info.turn}`;
     statusPlayer.textContent =
@@ -261,6 +267,10 @@ async function init() {
         : "Active Player: 2 (Aliens)";
     statusAP.textContent =
       typeof info.ap === "number" ? `AP remaining: ${info.ap}` : "";
+    statusCommand.textContent =
+      info.activePlayer === 1
+        ? `Command Points: ${info.commandPoints ?? 0}`
+        : "";
   };
   function render(state: any) {
     currentState = state;
@@ -308,11 +318,15 @@ async function init() {
       typeof mission.rules?.activeplayer === "number"
         ? mission.rules.activeplayer
         : 1;
+    const initCommandPoints =
+      typeof mission.rules?.commandpoints === "number"
+        ? mission.rules.commandpoints
+        : undefined;
     const rules = new Rules.BasicRules(
       board,
       () => renderer.render(board),
       updateStatus,
-      { turn: initTurn, activePlayer: initPlayer },
+      { turn: initTurn, activePlayer: initPlayer, commandPoints: initCommandPoints },
       logMessage,
     );
     currentRules = rules;
@@ -345,6 +359,7 @@ async function init() {
         reveal: btnReveal,
         deploy: btnDeploy,
         guard: btnGuard,
+        command: btnCommand,
         pass: btnPass,
       },
     }, logMessage);

--- a/Derelict/Game/tests/choose.test.js
+++ b/Derelict/Game/tests/choose.test.js
@@ -66,6 +66,7 @@ test('choose highlights activation options for different token types', async () 
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      command: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -142,6 +143,7 @@ test('move option takes precedence over door option on same cell', async () => {
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      command: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -222,6 +224,7 @@ test('move option takes precedence over assault option on same cell', async () =
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      command: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -312,6 +315,7 @@ test('door option takes precedence over assault option on same cell', async () =
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      command: new DummyButton(),
       pass: new DummyButton(),
     },
   };
@@ -392,6 +396,7 @@ test('binary action choice uses modal dialog', async () => {
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      command: new DummyButton(),
       pass: new DummyButton(),
     },
   };

--- a/Derelict/Game/tests/dispose.test.js
+++ b/Derelict/Game/tests/dispose.test.js
@@ -64,6 +64,7 @@ test("dispose clears overlays and listeners", () => {
       reveal: new DummyButton(),
       deploy: new DummyButton(),
       guard: new DummyButton(),
+      command: new DummyButton(),
       reroll: new DummyButton(),
       accept: new DummyButton(),
       pass: new DummyButton(),

--- a/Derelict/Game/types/external.d.ts
+++ b/Derelict/Game/types/external.d.ts
@@ -31,9 +31,11 @@ declare module 'derelict-players' {
       | 'deploy'
       | 'guard'
       | 'overwatch'
+      | 'command'
       | 'pass';
     apCost?: number;
     apRemaining?: number;
+    commandPointsRemaining?: number;
   }
   export interface GameApi {
     choose(options: Choice[]): Promise<Choice>;

--- a/Derelict/Players/src/index.ts
+++ b/Derelict/Players/src/index.ts
@@ -15,9 +15,11 @@ export interface Choice {
     | 'deploy'
     | 'guard'
     | 'overwatch'
+    | 'command'
     | 'pass';
   apCost?: number;
   apRemaining?: number;
+  commandPointsRemaining?: number;
 }
 
 // Game API that players can call to interact with the UI

--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -1018,11 +1018,13 @@ test('assault action offered and removes alien on win', async () => {
   let secondOpts;
   let tokensAfter;
   const originalRandom = Math.random;
-  const seq = [0.9, 0.1, 0.1, 0.1];
+  const seq = [0.5, 0.9, 0.1, 0.1, 0.1];
   Math.random = () => seq.shift() || 0;
   const player = {
     choose: async (options) => {
       calls++;
+      const accept = options.find((o) => o.action === 'accept');
+      if (accept) return accept;
       if (calls === 1) return options.find((o) => o.action === 'activate');
       if (calls === 2) {
         secondOpts = options;
@@ -1067,11 +1069,13 @@ test('assault ignores open door when enemy present', async () => {
   let secondOpts;
   let tokensAfter;
   const originalRandom = Math.random;
-  const seq = [0.9, 0.1, 0.1, 0.1];
+  const seq = [0.5, 0.9, 0.1, 0.1, 0.1];
   Math.random = () => seq.shift() || 0;
   const player = {
     choose: async (options) => {
       calls++;
+      const accept = options.find((o) => o.action === 'accept');
+      if (accept) return accept;
       if (calls === 1) return options.find((o) => o.action === 'activate');
       if (calls === 2) {
         secondOpts = options;
@@ -1112,6 +1116,8 @@ test('marine_chain assault destroys door', async () => {
   const player = {
     choose: async (options) => {
       calls++;
+      const accept = options.find((o) => o.action === 'accept');
+      if (accept) return accept;
       if (calls === 1) return options.find((o) => o.action === 'activate');
       if (calls === 2) return options.find((o) => o.action === 'assault');
       if (calls === 3) {
@@ -1145,17 +1151,20 @@ test('marine_hammer assault logs modifiers', async () => {
 
   let calls = 0;
   const originalRandom = Math.random;
-  const seq = [0.1, 0.9, 0.9];
+  const seq = [0.5, 0.1, 0.9, 0.9];
   Math.random = () => seq.shift() || 0;
   const player = {
     choose: async (options) => {
       calls++;
-      if (calls === 1) return options.find((o) => o.action === 'activate');
-      if (calls === 2) return options.find((o) => o.action === 'assault');
-      if (calls === 3) return options.find((o) => o.action === 'accept');
-      if (calls === 4) {
+      const accept = options.find((o) => o.action === 'accept');
+      if (accept) return accept;
+      const activate = options.find((o) => o.action === 'activate');
+      if (activate) return activate;
+      const assault = options.find((o) => o.action === 'assault');
+      if (assault) return assault;
+      if (options.some((o) => o.action === 'pass')) {
         board.tokens = [];
-        return options[0];
+        return options.find((o) => o.action === 'pass') || options[0];
       }
       return options[0];
     },

--- a/Derelict/Rules/types/external.d.ts
+++ b/Derelict/Rules/types/external.d.ts
@@ -32,9 +32,11 @@ declare module 'derelict-players' {
       | 'deploy'
       | 'guard'
       | 'overwatch'
+      | 'command'
       | 'pass';
     apCost?: number;
     apRemaining?: number;
+    commandPointsRemaining?: number;
   }
   export interface Player {
     choose(options: Choice[]): Promise<Choice>;


### PR DESCRIPTION
## Summary
- add marine command point tracking to the rules, including reroll prompts and the command-to-AP action
- expose command point totals through player choices and show them in the game UI with a new Command button
- update rules and game tests to cover the new command point flow and UI elements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d596ba1c208333a31cb73d9dcdc59a