### PR TITLE
Handle mission listing parsing on case-sensitive servers

### DIFF
--- a/Derelict/Editor/src/editor/EditorUI.ts
+++ b/Derelict/Editor/src/editor/EditorUI.ts
@@ -4,6 +4,7 @@ import { qs, createEl, showModal } from '../util/dom.js';
 import { pixelToCell, clampCell } from '../util/geometry.js';
 import { registerShortcuts } from './Shortcuts.js';
 import { downloadText, readFileAsText } from '../util/files.js';
+import { parseMissionListing } from '../util/missionListing.js';
 import type { Renderer, BoardState } from '../types.js';
 
 export class EditorUI {
@@ -278,8 +279,7 @@ export class EditorUI {
   private async fetchMissionList(): Promise<string[]> {
     const res = await fetch('missions/');
     const text = await res.text();
-    const matches = [...text.matchAll(/href="([^"/]+\.txt)"/g)];
-    return matches.map((m) => m[1]);
+    return parseMissionListing(text);
   }
 
   private getLocalMissionNames(): string[] {

--- a/Derelict/Editor/src/util/missionListing.ts
+++ b/Derelict/Editor/src/util/missionListing.ts
@@ -1,0 +1,8 @@
+export function parseMissionListing(text: string): string[] {
+  const names = new Set<string>();
+  const regex = /href\s*=\s*["']([^"'\/]+\.txt)["']/gi;
+  for (const match of text.matchAll(regex)) {
+    names.add(match[1]);
+  }
+  return [...names];
+}

--- a/Derelict/Editor/tests/missionListing.test.ts
+++ b/Derelict/Editor/tests/missionListing.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseMissionListing } from '../src/util/missionListing.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const missionsDir = join(__dirname, '..', '..', '..', 'public', 'missions');
+
+function createListing(items: string[]): string {
+  return [
+    '<html>',
+    '<body>',
+    '<UL>',
+    ...items.map((item, idx) =>
+      idx % 2 === 0
+        ? `<LI><A HREF="${item}">${item}</A></LI>`
+        : `<li><a href='${item}'>${item}</a></li>`
+    ),
+    '</UL>',
+    '</body>',
+    '</html>',
+  ].join('\n');
+}
+
+test('parseMissionListing finds mission files', () => {
+  const files = readdirSync(missionsDir).filter((file: string) => /\.txt$/i.test(file));
+  assert.ok(files.length >= 3, 'expected at least 3 mission files in public/missions');
+
+  const listing = createListing(files);
+  const parsed = parseMissionListing(listing);
+
+  assert.deepEqual(parsed.sort(), files.sort());
+  assert.ok(parsed.length >= 3);
+});

--- a/Derelict/Editor/tsconfig.json
+++ b/Derelict/Editor/tsconfig.json
@@ -10,6 +10,6 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src", "tests"],
+  "include": ["src", "tests", "types"],
   "exclude": ["dist"]
 }

--- a/Derelict/Editor/types/node-shim.d.ts
+++ b/Derelict/Editor/types/node-shim.d.ts
@@ -1,0 +1,31 @@
+declare module 'node:fs' {
+  export function readdirSync(
+    path: string | URL,
+    options?: { encoding?: BufferEncoding | null } | BufferEncoding | null,
+  ): string[];
+}
+
+declare module 'node:path' {
+  export function dirname(path: string): string;
+  export function join(...paths: string[]): string;
+}
+
+declare module 'node:url' {
+  export function fileURLToPath(url: string | URL): string;
+}
+
+declare module 'node:test' {
+  export function test(
+    name: string,
+    fn: () => void | Promise<void>,
+  ): void;
+}
+
+declare module 'node:assert/strict' {
+  const assert: {
+    (value: unknown, message?: string | Error): asserts value;
+    ok(value: unknown, message?: string | Error): asserts value;
+    deepEqual(actual: unknown, expected: unknown, message?: string | Error): void;
+  };
+  export default assert;
+}

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -1,5 +1,6 @@
 import { Game } from "./index.js";
 import { parseSegmentDefs } from "./segments.js";
+import { parseMissionListing } from "./util/missionListing.js";
 
 function createEl<K extends keyof HTMLElementTagNameMap>(
   tag: K,
@@ -62,8 +63,7 @@ function downloadText(name: string, text: string) {
 async function fetchMissionList(): Promise<string[]> {
   const res = await fetch("missions/");
   const text = await res.text();
-  const matches = [...text.matchAll(/href="([^"/]+\.txt)"/g)];
-  return matches.map((m) => m[1]);
+  return parseMissionListing(text);
 }
 
 async function init() {

--- a/Derelict/Game/src/util/missionListing.ts
+++ b/Derelict/Game/src/util/missionListing.ts
@@ -1,0 +1,8 @@
+export function parseMissionListing(text: string): string[] {
+  const names = new Set<string>();
+  const regex = /href\s*=\s*["']([^"'\/]+\.txt)["']/gi;
+  for (const match of text.matchAll(regex)) {
+    names.add(match[1]);
+  }
+  return [...names];
+}


### PR DESCRIPTION
## Summary
- make mission listing parsing case-insensitive via a shared helper for the editor and game
- add a unit test that exercises the parser against the missions directory listing
- include minimal node module shims so the new test compiles under TypeScript

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c6a62ad88333a3c23a6c4613bbb2