### PR TITLE
Use mission manifest for mission listing

### DIFF
--- a/Derelict/Editor/src/editor/EditorUI.ts
+++ b/Derelict/Editor/src/editor/EditorUI.ts
@@ -276,10 +276,13 @@ export class EditorUI {
   }
 
   private async fetchMissionList(): Promise<string[]> {
-    const res = await fetch('missions/');
+    const res = await fetch('missions/missions.txt');
+    if (!res.ok) return [];
     const text = await res.text();
-    const matches = [...text.matchAll(/href="([^"/]+\.txt)"/g)];
-    return matches.map((m) => m[1]);
+    return text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'));
   }
 
   private getLocalMissionNames(): string[] {

--- a/Derelict/Game/src/main.ts
+++ b/Derelict/Game/src/main.ts
@@ -60,10 +60,13 @@ function downloadText(name: string, text: string) {
 }
 
 async function fetchMissionList(): Promise<string[]> {
-  const res = await fetch("missions/");
+  const res = await fetch("missions/missions.txt");
+  if (!res.ok) return [];
   const text = await res.text();
-  const matches = [...text.matchAll(/href="([^"/]+\.txt)"/g)];
-  return matches.map((m) => m[1]);
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
 }
 
 async function init() {

--- a/Derelict/public/missions/missions.txt
+++ b/Derelict/public/missions/missions.txt
@@ -1,0 +1,3 @@
+Cleanse-The-Corridor.txt
+Suicide-Mission.txt
+Wipe-The-Floor.txt


### PR DESCRIPTION
## Summary
- update the editor and game mission list loaders to read from a mission manifest file instead of relying on directory listings
- add a missions.txt manifest enumerating the available server missions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e95f21d48333bee447913eaa734d