### PR TITLE
Fix editor Play button navigation

### DIFF
--- a/Derelict/Editor/src/editor/EditorUI.ts
+++ b/Derelict/Editor/src/editor/EditorUI.ts
@@ -91,6 +91,23 @@ export class EditorUI {
       this.openSaveDialog();
     });
 
+    const playBtn = qs<HTMLButtonElement>(this.container, '#btn-play');
+    playBtn.addEventListener('click', () => {
+      const body = createEl('div');
+      body.textContent = 'Open game view? Unsaved changes will be lost.';
+      let ref: { close(): void };
+      ref = showModal('Play Mission', body, [
+        {
+          label: 'OK',
+          onClick: () => {
+            ref.close();
+            window.location.href = 'game.html';
+          },
+        },
+        { label: 'Cancel', onClick: () => ref.close() },
+      ]);
+    });
+
     const newBtn = qs<HTMLButtonElement>(this.container, '#btn-new');
     newBtn.addEventListener('click', () => {
       const body = createEl('div');


### PR DESCRIPTION
## Summary
- add a click handler for the editor Play button that confirms leaving and navigates to the game view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dda6634eb48333a063dd5adbd1f76a