### PR TITLE
Allow marines to reactivate with command points

### DIFF
--- a/Derelict/Rules/tests/basic.test.js
+++ b/Derelict/Rules/tests/basic.test.js
@@ -515,7 +515,7 @@ test('blip cannot move into marine', async () => {
   );
 });
 
-test('activating different unit marks previous as deactivated until pass', async () => {
+test('activating different unit marks previous as deactivated but marines may reactivate with command points', async () => {
   const board = {
     size: 5,
     segments: [],
@@ -563,11 +563,12 @@ test('activating different unit marks previous as deactivated until pass', async
   await rules.runGame(p1, p2);
 
   assert.ok(hadDeactDuringTurn);
-  assert.ok(
-    !optionsAfterSwitch.some(
-      (o) => o.action === 'activate' && o.coord?.x === 0 && o.coord?.y === 0,
-    ),
+  const reactivationOption = optionsAfterSwitch.find(
+    (o) => o.action === 'activate' && o.coord?.x === 0 && o.coord?.y === 0,
   );
+  assert.ok(reactivationOption);
+  assert.strictEqual(reactivationOption.apRemaining, 0);
+  assert.ok((reactivationOption.commandPointsRemaining ?? 0) > 0);
   assert.ok(!tokensAfterPass.some((t) => t.type === 'deactivated'));
 });
 


### PR DESCRIPTION
## Summary
- allow marines with a deactivated token to appear as activation options when command points remain
- ensure reactivating a deactivated marine clears the token and starts with 0 AP
- update the activation test to cover the new command point driven behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68defb8b87e88333837f2f59a67b0db6