### PR TITLE
Improve reveal logging and activation targeting

### DIFF
--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -254,59 +254,88 @@ export class BasicRules implements Rules {
         const hadDeact = hasDeactivatedToken(this.board, origin);
         this.onChange?.(this.board);
         this.emitStatus(undefined, 2);
-        this.onLog?.('Blip revealed as alien; choose its orientation');
-        await orientAlien(
-          p2,
-          target,
-          [{ type: 'action', action: 'pass', apCost: 0, apRemaining: 0 }],
-          this.board,
-          this.onChange?.bind(this),
-          0,
-          this.onLog,
+        const initialDeployCells = getDeployCells(this.board, origin, true);
+        const totalAliensText =
+          maxTotal <= 0
+            ? 'no aliens'
+            : maxTotal === 1
+            ? '1 alien'
+            : `${maxTotal} aliens`;
+        const availableCellsText = `${initialDeployCells.length} deployment cell${
+          initialDeployCells.length === 1 ? '' : 's'
+        } available`;
+        const revealSuffix = maxTotal <= 0 ? '' : ' (including the revealed alien)';
+        this.onLog?.(
+          `Forced reveal will place ${totalAliensText}${revealSuffix} with ${availableCellsText}`,
         );
         let remaining = maxTotal - 1;
-        while (remaining > 0) {
-          const deployCells = getDeployCells(this.board, origin, true);
-          if (deployCells.length === 0) break;
-          this.emitStatus(undefined, 1);
-          const choice = await p1.choose(
-            deployCells.map((c) => ({
+        let current: TokenInstance = target;
+        let firstOrientation = true;
+        while (true) {
+          const deployCells = remaining > 0 ? getDeployCells(this.board, origin, true) : [];
+          const extras: Choice[] = [];
+          if (deployCells.length > 0 && remaining > 0) {
+            extras.push(
+              ...deployCells.map((c) => ({
+                type: 'action' as const,
+                action: 'deploy' as const,
+                coord: c,
+                apCost: 0,
+                apRemaining: 0,
+              })),
+            );
+          }
+          if (remaining === 0 || deployCells.length === 0) {
+            extras.push({
               type: 'action' as const,
-              action: 'deploy' as const,
-              coord: c,
+              action: 'pass' as const,
               apCost: 0,
               apRemaining: 0,
-            })),
-          );
-          if (choice.action !== 'deploy' || !choice.coord) break;
-          const newAlien: TokenInstance = {
-            instanceId: `alien-${this.nextAlienId++}`,
-            type: 'alien',
-            rot: target.rot,
-            cells: [{ ...choice.coord }],
-          };
-          this.board.tokens.push(newAlien);
-          if (hadDeact) {
-            this.board.tokens.push({
-              instanceId: `deactivated-${this.nextDeactId++}`,
-              type: 'deactivated',
-              rot: 0,
-              cells: [{ ...choice.coord }],
             });
           }
-          this.onChange?.(this.board);
-          this.emitStatus(undefined, 2);
-          this.onLog?.('Blip reveals additional alien; choose its orientation');
-          await orientAlien(
+          if (firstOrientation) {
+            this.onLog?.('Blip revealed as alien; choose its orientation');
+          } else {
+            this.onLog?.('Blip reveals additional alien; choose its orientation');
+          }
+          this.onLog?.('Alien player: orient the current alien or choose another action');
+          const choice = await orientAlien(
             p2,
-            newAlien,
-            [{ type: 'action', action: 'pass', apCost: 0, apRemaining: 0 }],
+            current,
+            extras,
             this.board,
             this.onChange?.bind(this),
             0,
             this.onLog,
           );
-          remaining--;
+          if (choice.action === 'deploy' && choice.coord) {
+            const chosenCoord = deployCells.find((c) => sameCoord(c, choice.coord!));
+            if (!chosenCoord) {
+              continue;
+            }
+            const newAlien: TokenInstance = {
+              instanceId: `alien-${this.nextAlienId++}`,
+              type: 'alien',
+              rot: current.rot,
+              cells: [{ ...chosenCoord }],
+            };
+            this.board.tokens.push(newAlien);
+            if (hadDeact) {
+              this.board.tokens.push({
+                instanceId: `deactivated-${this.nextDeactId++}`,
+                type: 'deactivated',
+                rot: 0,
+                cells: [{ ...chosenCoord }],
+              });
+            }
+            this.onChange?.(this.board);
+            this.emitStatus(undefined, 2);
+            current = newAlien;
+            remaining--;
+            firstOrientation = false;
+            continue;
+          }
+          break;
         }
       }
     };

--- a/Derelict/Rules/src/index.ts
+++ b/Derelict/Rules/src/index.ts
@@ -1531,15 +1531,13 @@ export class BasicRules implements Rules {
                     !hasDeactivatedToken(this.board, t.cells[0]),
                 );
                 for (const t of avail) {
-                  if (t !== current) {
-                    extras.push({
-                      type: 'action' as const,
-                      action: 'activate' as const,
-                      coord: t.cells[0],
-                      apCost: 0,
-                      apRemaining: initialAp(t),
-                    });
-                  }
+                  extras.push({
+                    type: 'action' as const,
+                    action: 'activate' as const,
+                    coord: t.cells[0],
+                    apCost: 0,
+                    apRemaining: initialAp(t),
+                  });
                 }
                 extras.push({
                   type: 'action' as const,


### PR DESCRIPTION
## Summary
- log the number of aliens produced by a reveal and the number of deployment cells before placement begins
- avoid duplicate orientation prompts when calling orientAlien
- ensure activating a token on a lurk selects the blip/alien rather than the lurk token

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e2d8e16e148333add7c8789f1fcc9f